### PR TITLE
fix: test results must overwrite an existing file.

### DIFF
--- a/src/TestLogger/Platform/FileSystem.cs
+++ b/src/TestLogger/Platform/FileSystem.cs
@@ -46,7 +46,7 @@ namespace Spekt.TestLogger.Platform
 
         public void Write(string path, string content)
         {
-            using (var writer = new StreamWriter(new FileStream(path, FileMode.OpenOrCreate)))
+            using (var writer = new StreamWriter(new FileStream(path, FileMode.Create)))
             {
                 writer.Write(content);
             }

--- a/test/TestLogger.UnitTests/Platform/BaseFileSystemTests.cs
+++ b/test/TestLogger.UnitTests/Platform/BaseFileSystemTests.cs
@@ -103,6 +103,17 @@ namespace Spekt.TestLogger.UnitTests.Platform
         }
 
         [TestMethod]
+        public void WriteShouldOverwriteFileWithContent()
+        {
+            var dummyFile = GetTempFile("dummyFile.txt");
+            this.fileSystem.Write(dummyFile, "Dummy content extra");
+
+            this.fileSystem.Write(dummyFile, "Dummy content");
+
+            Assert.AreEqual("Dummy content", this.fileSystem.Read(dummyFile));
+        }
+
+        [TestMethod]
         public void DeleteShouldRemoveTheFile()
         {
             var dummyFile = GetTempFile("dummyDeleteFile.txt");


### PR DESCRIPTION
Fixes https://github.com/spekt/nunit.testlogger/issues/76