### PR TITLE
Remove TestResultInfo.Name from public API.

### DIFF
--- a/src/TestLogger/Core/TestResultInfo.cs
+++ b/src/TestLogger/Core/TestResultInfo.cs
@@ -42,8 +42,6 @@ namespace Spekt.TestLogger.Core
         /// </summary>
         public string Method { get; internal set; }
 
-        public string Name => this.result.TestCase.DisplayName;
-
         public DateTime StartTime => this.result.StartTime.UtcDateTime;
 
         public DateTime EndTime => this.result.EndTime.UtcDateTime;

--- a/src/TestLogger/Extensions/XunitTestAdapter.cs
+++ b/src/TestLogger/Extensions/XunitTestAdapter.cs
@@ -40,7 +40,7 @@ namespace Spekt.TestLogger.Extensions
 
             foreach (var result in results)
             {
-                if (skippedTestNamesWithReason.TryGetValue(result.Name, out var skipReason))
+                if (skippedTestNamesWithReason.TryGetValue(result.Result.DisplayName, out var skipReason))
                 {
                     // TODO: Defining a new category for now...
                     result.Messages.Add(new TestResultMessage("skipReason", skipReason));

--- a/src/TestLogger/Extensions/XunitTestAdapter.cs
+++ b/src/TestLogger/Extensions/XunitTestAdapter.cs
@@ -40,7 +40,7 @@ namespace Spekt.TestLogger.Extensions
 
             foreach (var result in results)
             {
-                if (skippedTestNamesWithReason.TryGetValue(result.Result.DisplayName, out var skipReason))
+                if (skippedTestNamesWithReason.TryGetValue(result.Result.TestCase.DisplayName, out var skipReason))
                 {
                     // TODO: Defining a new category for now...
                     result.Messages.Add(new TestResultMessage("skipReason", skipReason));

--- a/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
+++ b/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
@@ -54,7 +54,6 @@ namespace Spekt.TestLogger.UnitTests
             Assert.AreEqual("SampleNamespace", results[0].Namespace);
             Assert.AreEqual("SampleClass", results[0].Type);
             Assert.AreEqual("SampleNamespace.SampleClass", results[0].FullTypeName);
-            Assert.AreEqual("SampleNamespace.SampleClass.SampleTest", results[0].Method);
             Assert.AreEqual("SampleTest", results[0].Method);
             Assert.AreEqual(this.dummyTestCase, results[0].TestCase);
             Assert.AreEqual(DummySourceFile, results[0].AssemblyPath);

--- a/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
+++ b/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
@@ -54,7 +54,7 @@ namespace Spekt.TestLogger.UnitTests
             Assert.AreEqual("SampleNamespace", results[0].Namespace);
             Assert.AreEqual("SampleClass", results[0].Type);
             Assert.AreEqual("SampleNamespace.SampleClass", results[0].FullTypeName);
-            Assert.AreEqual("SampleNamespace.SampleClass.SampleTest", results[0].Name);
+            Assert.AreEqual("SampleNamespace.SampleClass.SampleTest", results[0].Method);
             Assert.AreEqual("SampleTest", results[0].Method);
             Assert.AreEqual(this.dummyTestCase, results[0].TestCase);
             Assert.AreEqual(DummySourceFile, results[0].AssemblyPath);


### PR DESCRIPTION
After working on https://github.com/spekt/junit.testlogger/pull/45 I think we would be better off removing this from TestResultInfo. 

I believe we intend to use use `Method` in all of our logged output, and 'DisplayName' is only helpful in the ITestAdapters. I took a quick look and I think its only the Junit logger that was logging `Name` by accident.