### PR TITLE
feat: add nunit test adapter to transform tests marked with Explicit attribute to Skipped instead of Inconclusive outcome.

### DIFF
--- a/src/TestLogger/Core/TestResultInfo.cs
+++ b/src/TestLogger/Core/TestResultInfo.cs
@@ -22,11 +22,12 @@ namespace Spekt.TestLogger.Core
             this.Namespace = @namespace;
             this.Type = type;
             this.Method = method;
+            this.Outcome = result.Outcome;
         }
 
         public TestCase TestCase => this.result.TestCase;
 
-        public TestOutcome Outcome => this.result.Outcome;
+        public TestOutcome Outcome { get; set; }
 
         public string AssemblyPath => this.result.TestCase.Source;
 

--- a/src/TestLogger/Extensions/MSTestAdapter.cs
+++ b/src/TestLogger/Extensions/MSTestAdapter.cs
@@ -27,7 +27,7 @@ namespace Spekt.TestLogger.Extensions
                 }
                 else if (method != displayName)
                 {
-                        result.Method = displayName;
+                    result.Method = displayName;
                 }
             }
 

--- a/src/TestLogger/Extensions/NUnitTestAdapter.cs
+++ b/src/TestLogger/Extensions/NUnitTestAdapter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Spekt.TestLogger.Core;
+
+    public class NUnitTestAdapter : ITestAdapter
+    {
+        private const string ExplicitLabel = "Explicit";
+
+        public List<TestResultInfo> TransformResults(List<TestResultInfo> results, List<TestMessageInfo> messages)
+        {
+            foreach (var result in results)
+            {
+                // Mark tests with Explicit attribute as Skipped instead of Inconclusive.
+                if (result.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.None &&
+                    result.TestCase.Traits.Any(trait => trait.Name.Equals(ExplicitLabel, StringComparison.OrdinalIgnoreCase)))
+                {
+                    result.Outcome = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Skipped;
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/TestLogger/Extensions/NUnitTestAdapter.cs
+++ b/src/TestLogger/Extensions/NUnitTestAdapter.cs
@@ -17,7 +17,9 @@ namespace Spekt.TestLogger.Extensions
         {
             foreach (var result in results)
             {
-                // Mark tests with Explicit attribute as Skipped instead of Inconclusive.
+                // Mark tests with Explicit attribute as Skipped instead of Inconclusive. Explicit
+                // is passed as a trait in the test platform. NUnit explicit attribute spec:
+                // https://docs.nunit.org/articles/nunit/writing-tests/attributes/explicit.html
                 if (result.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.None &&
                     result.TestCase.Traits.Any(trait => trait.Name.Equals(ExplicitLabel, StringComparison.OrdinalIgnoreCase)))
                 {

--- a/src/TestLogger/Extensions/TestAdapterFactory.cs
+++ b/src/TestLogger/Extensions/TestAdapterFactory.cs
@@ -3,8 +3,6 @@
 
 namespace Spekt.TestLogger.Extensions
 {
-    using Spekt.TestLogger.Core;
-
     public class TestAdapterFactory : ITestAdapterFactory
     {
         public ITestAdapter CreateTestAdapter(string executorUri)
@@ -16,6 +14,10 @@ namespace Spekt.TestLogger.Extensions
             else if (!string.IsNullOrEmpty(executorUri) && executorUri.ToLowerInvariant().Contains("mstest"))
             {
                 return new MSTestAdapter();
+            }
+            else if (!string.IsNullOrEmpty(executorUri) && executorUri.ToLowerInvariant().Contains("nunit"))
+            {
+                return new NUnitTestAdapter();
             }
 
             return new DefaultTestAdapter();

--- a/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.UnitTests.Extensions
+{
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Spekt.TestLogger.Core;
+    using Spekt.TestLogger.Extensions;
+
+    [TestClass]
+    public class NUnitTestAdapterTests
+    {
+        private const string DummyNamespace = "DummyNamespace";
+        private const string DummyType = "DummyType";
+        private const string DummyMethod = "DummyMethod";
+        private readonly NUnitTestAdapter adapter;
+        private readonly TestCase dummyTestCase;
+        private readonly TestCase explicitTestCase;
+        private readonly TestResultInfo passTestResultInfo;
+        private readonly TestResultInfo failTestResultInfo;
+
+        public NUnitTestAdapterTests()
+        {
+            this.adapter = new NUnitTestAdapter();
+            this.dummyTestCase = new TestCase();
+            this.explicitTestCase = new TestCase();
+            this.explicitTestCase.Traits.Add("Explicit", string.Empty);
+
+            var passTestResult = new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult(this.dummyTestCase) { Outcome = TestOutcome.Passed };
+            this.passTestResultInfo = new TestResultInfo(passTestResult, DummyNamespace, DummyType, DummyMethod);
+
+            var failTestResult = new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult(this.dummyTestCase) { Outcome = TestOutcome.Failed };
+            this.failTestResultInfo = new TestResultInfo(failTestResult, DummyNamespace, DummyType, DummyMethod);
+        }
+
+        [DataTestMethod]
+        [DataRow(TestOutcome.Passed)]
+        [DataRow(TestOutcome.Skipped)]
+        [DataRow(TestOutcome.Failed)]
+        [DataRow(TestOutcome.NotFound)]
+        public void TransformResultsShouldNotModifyNonInclusiveTests(TestOutcome outcome)
+        {
+            var result = new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult(this.dummyTestCase) { Outcome = outcome };
+            var explicitResult = new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult(this.explicitTestCase) { Outcome = outcome };
+            var results = new List<TestResultInfo>
+            {
+                new TestResultInfo(result, DummyNamespace, DummyType, DummyMethod),
+                new TestResultInfo(explicitResult, DummyNamespace, DummyType, DummyMethod)
+            };
+
+            var modifiedResults = this.adapter.TransformResults(results, new ());
+
+            Assert.AreEqual(2, modifiedResults.Count);
+            Assert.AreEqual(outcome, modifiedResults[0].Outcome);
+            Assert.AreEqual(outcome, modifiedResults[1].Outcome);
+        }
+
+        [TestMethod]
+        public void TransformResultsShouldNotModifyTestWithoutExplicitAttribute()
+        {
+            var results = new List<TestResultInfo> { this.passTestResultInfo, this.failTestResultInfo };
+
+            var modifiedResults = this.adapter.TransformResults(results, new ());
+
+            Assert.AreEqual(2, modifiedResults.Count);
+            Assert.AreEqual(TestOutcome.Passed, modifiedResults[0].Outcome);
+            Assert.AreEqual(TestOutcome.Failed, modifiedResults[1].Outcome);
+        }
+
+        [TestMethod]
+        public void TransformResultShouldModifyTestWithExplicitAttributeAndNoOutcome()
+        {
+            var explicitResult = new Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult(this.explicitTestCase) { Outcome = TestOutcome.None };
+            var results = new List<TestResultInfo>
+            {
+                new TestResultInfo(explicitResult, DummyNamespace, DummyType, DummyMethod)
+            };
+
+            var modifiedResults = this.adapter.TransformResults(results, new ());
+
+            Assert.AreEqual(1, modifiedResults.Count);
+            Assert.AreEqual(TestOutcome.Skipped, modifiedResults[0].Outcome);
+        }
+    }
+}

--- a/test/TestLogger.UnitTests/Extensions/TestAdapterFactoryTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/TestAdapterFactoryTests.cs
@@ -12,6 +12,7 @@ namespace Spekt.TestLogger.UnitTests.Extensions
         [TestMethod]
         [DataRow("")]
         [DataRow(null)]
+        [DataRow("executor://NotExitTestExecutor")]
         public void CreateTestAdapterShouldReturnDefaultAdapterIfExecutorUriIsInvalid(string executorUri)
         {
             var factory = new TestAdapterFactory();
@@ -23,13 +24,13 @@ namespace Spekt.TestLogger.UnitTests.Extensions
 
         [TestMethod]
         [DataRow("executor://NUnit3TestExecutor")]
-        public void CreateTestAdapterShouldReturnDefaultAdapterForNonXunitFramework(string executorUri)
+        public void CreateTestAdapterShouldReturnNUnitAdapterForNUnitFramework(string executorUri)
         {
             var factory = new TestAdapterFactory();
 
             var adapter = factory.CreateTestAdapter(executorUri);
 
-            Assert.IsTrue(adapter is DefaultTestAdapter);
+            Assert.IsTrue(adapter is NUnitTestAdapter);
         }
 
         [TestMethod]


### PR DESCRIPTION
See https://github.com/spekt/nunit.testlogger/issues/86