### PR TITLE
Include [Theory] data in xUnit test names

### DIFF
--- a/src/TestLogger/Extensions/XunitTestAdapter.cs
+++ b/src/TestLogger/Extensions/XunitTestAdapter.cs
@@ -46,6 +46,14 @@ namespace Spekt.TestLogger.Extensions
                     result.Messages.Add(new TestResultMessage("skipReason", skipReason));
                 }
 
+                string displayName = result.Result.DisplayName;
+                
+                // Add parameters for theories.
+                if (displayName.Contains("("))
+                {
+                    result.Method += displayName.Substring(displayName.IndexOf("("));
+                }
+
                 transformedResults.Add(result);
             }
 


### PR DESCRIPTION
This fixes https://github.com/spekt/junit.testlogger/issues/50 by including the xUnit theory data in test names.