### PR TITLE
Update codecov-action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
           **/*.verified.txt
           **/*.received.txt
     - name: Codecov
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v3.1.0
       with:
         files: test/TestLogger.UnitTests/coverage.opencover.xml
     - name: Publish packages


### PR DESCRIPTION
Removes deprecated version. 

Not at all urgent. I just noticed this was behind.