### PR TITLE
feat: add testproperty to TestResultInfo for Nunit scenarios.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -15,38 +15,38 @@ jobs:
     env:
       APP_BUILD_VERSION: ${{ format('3.0.{0}', github.run_number) }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 7.0.x
-    - name: Setup .NET 3.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Package (debug)
-      run: dotnet pack -p:PackageVersion=$APP_BUILD_VERSION
-    - name: Package (release)
-      run: dotnet pack -c Release -p:PackageVersion=$APP_BUILD_VERSION
-    - name: Unit test
-      run: dotnet test -p:PackageVersion=$APP_BUILD_VERSION test/TestLogger.UnitTests/TestLogger.UnitTests.csproj -p:CollectCoverage=true -p:CoverletOutputFormat=opencover
-    - name: Acceptance test
-      run: dotnet test -p:PackageVersion=$APP_BUILD_VERSION test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
-    - name: Upload Verification Files on Fail
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: Acceptance Test Failure
-        retention-days: 5
-        path: |
-          **/*.verified.txt
-          **/*.received.txt
-    - name: Codecov
-      uses: codecov/codecov-action@v3.1.0
-      with:
-        files: test/TestLogger.UnitTests/coverage.opencover.xml
-    - name: Publish packages
-      if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
-      run: |
-        dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/spekt/index.json
-        dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.SPEKT_MYGET_KEY }} --source https://www.myget.org/F/spekt/api/v3/index.json 
+      - uses: actions/checkout@v2
+      - name: Setup .NET 7.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.0.x
+      - name: Setup .NET 3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
+      - name: Package (debug)
+        run: dotnet pack -p:PackageVersion=${{ env.APP_BUILD_VERSION }}
+      - name: Package (release)
+        run: dotnet pack -c Release -p:PackageVersion=${{ env.APP_BUILD_VERSION }}
+      - name: Unit test
+        run: dotnet test -p:PackageVersion=${{ env.APP_BUILD_VERSION }} test/TestLogger.UnitTests/TestLogger.UnitTests.csproj -p:CollectCoverage=true -p:CoverletOutputFormat=opencover
+      - name: Acceptance test
+        run: dotnet test -p:PackageVersion=${{ env.APP_BUILD_VERSION }} test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
+      - name: Upload Verification Files on Fail
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Acceptance Test Failure
+          retention-days: 5
+          path: |
+            **/*.verified.txt
+            **/*.received.txt
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          files: test/TestLogger.UnitTests/coverage.opencover.xml
+      - name: Publish packages
+        if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
+        run: |
+          dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/spekt/index.json
+          dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.SPEKT_MYGET_KEY }} --source https://www.myget.org/F/spekt/api/v3/index.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       APP_BUILD_VERSION: ${{ format('3.0.{0}', github.run_number) }}
     steps:
@@ -43,7 +46,7 @@ jobs:
       with:
         files: test/TestLogger.UnitTests/coverage.opencover.xml
     - name: Publish packages
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
       run: |
         dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/spekt/index.json
         dotnet nuget push 'src/TestLogger/bin/Release/*.nupkg' --api-key ${{ secrets.SPEKT_MYGET_KEY }} --source https://www.myget.org/F/spekt/api/v3/index.json 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,10 +13,10 @@ jobs:
       APP_BUILD_VERSION: ${{ format('3.0.{0}', github.run_number) }}
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 5.0
+    - name: Setup .NET 7.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
     - name: Setup .NET 3.1.x
       uses: actions/setup-dotnet@v1
       with:

--- a/README.md
+++ b/README.md
@@ -10,5 +10,18 @@ Common test logger abstractions for [Visual Studio Test Platform](https://gtihub
 | ------ | -------------- |
 | Spekt.TestLogger | https://github.com/spekt/testlogger/packages/580072 |
 
+## Contribution Guide
+
+Run the `build.ps1` or `build.sh` scripts in Windows or Linux to build and run the tests.
+
+This repo always requires the latest LTS release of dotnet and dotnet runtime 3.1 for development.
+
+If acceptance tests are failing, try running this command to see detailed output:
+
+```sh
+# Run from root of repo
+> dotnet test --no-build --logger:"json;LogFilePath=test-results.json" test/assets/Json.TestLogger.MSTest.NetCore.Tests/Json.TestLogger.MSTest.NetCore.Tests.csproj
+```
+
 ## License
 MIT

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -10,8 +10,8 @@
     <NETTestSdkMinimumVersion>15.0.0</NETTestSdkMinimumVersion>
     <XunitVersion>2.3.1</XunitVersion>
     <XunitTestAdapterVersion>2.3.1</XunitTestAdapterVersion>
-    <NUnitVersion>3.10.1</NUnitVersion>
-    <NUnitTestAdapterVersion>3.10.0</NUnitTestAdapterVersion>
+    <NUnitVersion>3.13.2</NUnitVersion>
+    <NUnitTestAdapterVersion>4.0.0</NUnitTestAdapterVersion>
 
     <!-- Only use stable versions of stylecop -->
     <StylecopVersion>1.1.118</StylecopVersion>

--- a/src/TestLogger/Core/TestResultInfo.cs
+++ b/src/TestLogger/Core/TestResultInfo.cs
@@ -27,6 +27,7 @@ namespace Spekt.TestLogger.Core
             string errorStackTrace,
             List<TestResultMessage> messages,
             IReadOnlyCollection<Trait> traits,
+            IReadOnlyCollection<KeyValuePair<string, object>> properties,
             string executorUri)
         {
             this.Namespace = @namespace;
@@ -46,6 +47,7 @@ namespace Spekt.TestLogger.Core
             this.ErrorStackTrace = errorStackTrace;
             this.Messages = messages;
             this.Traits = traits;
+            this.Properties = properties;
             this.ExecutorUri = executorUri;
         }
 
@@ -80,6 +82,16 @@ namespace Spekt.TestLogger.Core
         public List<TestResultMessage> Messages { get; }
 
         public IReadOnlyCollection<Trait> Traits { get; }
+
+        /// <summary>
+        /// Gets the collection of properties set by the test adapter for the
+        /// test case.
+        /// </summary>
+        /// <remarks>
+        /// Used for NUnit results - NUnit.Seed and NUnit.TestCategory.
+        /// Value is an object, not necessarily a string, hence not sanitized.
+        /// </remarks>
+        public IReadOnlyCollection<KeyValuePair<string, object>> Properties { get; }
 
         public string ExecutorUri { get; }
 

--- a/src/TestLogger/Core/TestRunResultWorkflow.cs
+++ b/src/TestLogger/Core/TestRunResultWorkflow.cs
@@ -4,9 +4,11 @@
 namespace Spekt.TestLogger.Core
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using Spekt.TestLogger.Extensions;
 
     public static class TestRunResultWorkflow
     {
@@ -45,6 +47,7 @@ namespace Spekt.TestLogger.Core
                 sanitize(result.ErrorStackTrace),
                 result.Messages.Select(x => new TestResultMessage(sanitize(x.Category), sanitize(x.Text))).ToList(),
                 result.TestCase.Traits.Select(x => new Trait(sanitize(x.Name), sanitize(x.Value))).ToList(),
+                result.TestCase.Properties.Select(x => new KeyValuePair<string, object>(x.Id, result.TestCase.GetPropertyValue(x))).ToList(), // Cannot sanitize since the value is object (not always string)
                 result.TestCase.ExecutorUri?.ToString()));
         }
     }

--- a/test/TestLogger.AcceptanceTests/DotnetTestFixture.cs
+++ b/test/TestLogger.AcceptanceTests/DotnetTestFixture.cs
@@ -45,6 +45,9 @@ namespace TestLogger.AcceptanceTests
                     Arguments = $"test --no-build --logger:\"json;LogFilePath={ResultFile}{args}\" {GetAssemblyPath(assemblyName)}\\{assemblyName}.csproj"
                 }
             };
+
+            // Required to skip icu requirement for netcoreapp3.1 in linux
+            dotnet.StartInfo.EnvironmentVariables["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1";
             dotnet.Start();
 
             Console.WriteLine("dotnet arguments: " + dotnet.StartInfo.Arguments);

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
@@ -11,7 +11,60 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -19,7 +72,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -27,7 +144,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -35,7 +216,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -43,7 +288,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -51,7 +360,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -59,7 +432,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1
+                ]
+              }
+            ]
           }
         ]
       },
@@ -72,7 +509,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is null
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  "ABCDE",
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  3,
+                  null,
+                  null
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -80,7 +585,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is empty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  "",
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  3,
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  ""
+                ]
+              }
+            ]
           }
         ]
       },
@@ -93,7 +666,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -101,7 +727,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -109,7 +803,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  12,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  30,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -117,7 +879,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  14,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  15
+                ]
+              }
+            ]
           }
         ]
       },
@@ -130,7 +960,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -138,7 +1036,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  12,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  30,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -146,7 +1112,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  14,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  15
+                ]
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetFull.Tests-WindowsOnly.verified.txt
@@ -11,7 +11,60 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -19,7 +72,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -27,7 +144,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -35,7 +216,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -43,7 +288,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -51,7 +360,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -59,7 +432,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1
+                ]
+              }
+            ]
           }
         ]
       },
@@ -72,7 +509,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is null
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  "ABCDE",
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  3,
+                  null,
+                  null
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -80,7 +585,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is empty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  "",
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  3,
+                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  ""
+                ]
+              }
+            ]
           }
         ]
       },
@@ -93,7 +666,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -101,7 +727,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -109,7 +803,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  12,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  30,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -117,7 +879,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  14,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  15
+                ]
+              }
+            ]
           }
         ]
       },
@@ -130,7 +960,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -138,7 +1036,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  12,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  30,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -146,7 +1112,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  14,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  1,
+                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
+                  15
+                ]
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetMulti.Tests.verified.txt
@@ -11,7 +11,60 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -19,7 +72,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -27,7 +144,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -35,7 +216,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: TestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -43,7 +288,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (-1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  -1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -51,7 +360,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  0
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -59,7 +432,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: DataTestMethodDataRow (1)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: DataTestMethodDataRow(System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  UnitTest2
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1
+                ]
+              }
+            ]
           }
         ]
       },
@@ -72,7 +509,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is null
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  "ABCDE",
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  3,
+                  null,
+                  null
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -80,7 +585,75 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: When string is empty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Substring(System.String,System.Int32,System.String)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.Tests2,
+                  DataRowWithDisplayName
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  "",
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  3,
+                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  ""
+                ]
+              }
+            ]
           }
         ]
       },
@@ -93,7 +666,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleFailure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: ExampleFailure
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -101,7 +727,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -109,7 +803,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  12,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  30,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -117,7 +879,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Custom - Test_Add (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  UnitTest1
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  14,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  15
+                ]
+              }
+            ]
           }
         ]
       },
@@ -130,7 +960,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (1,1,2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  2
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -138,7 +1036,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (12,30,42)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  12,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  30,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  42
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -146,7 +1112,75 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test_Add_DynamicData_Property (14,1,15)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://MSTestAdapter/v2
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
+              },
+              {
+                Key: TestCase.ManagedType,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.ManagedMethod,
+                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
+              },
+              {
+                Key: MSTestDiscoverer.TestClassName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
+              },
+              {
+                Key: TestCase.Hierarchy,
+                Value: [
+                  NUnit.Xml.TestLogger.NetFull.Tests,
+                  MathTests
+                ]
+              },
+              {
+                Key: TestObject.Traits,
+                Value: []
+              },
+              {
+                Key: MSTest.DynamicDataType,
+                Value: 2
+              },
+              {
+                Key: MSTest.DynamicData,
+                Value: [
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  14,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  1,
+                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
+                  15
+                ]
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
@@ -11,7 +11,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((, )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((, ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((, ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test)),
@@ -19,7 +49,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((test, test)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((test, test))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\\, \\\\)),
@@ -27,7 +87,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((\\, \\\\)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((\, \\))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\, \\))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  )),
@@ -35,7 +125,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples(([,  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples(([,  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  )),
@@ -43,7 +163,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((],  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((],  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0'),
@@ -51,7 +201,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('0'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('0')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a'),
@@ -59,7 +239,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('a'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('a')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A'),
@@ -67,7 +277,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('A'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('A')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!'),
@@ -75,7 +315,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('!'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('!')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-'),
@@ -83,7 +353,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('-'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('-')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_'),
@@ -91,7 +391,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('_'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('_')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.'),
@@ -99,7 +429,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('.'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('.')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*'),
@@ -107,7 +467,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('*'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('*')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\\''),
@@ -115,7 +505,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('\\''),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('('),
@@ -123,7 +543,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('('),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('(')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')'),
@@ -131,7 +581,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3(')'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3(')')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/'),
@@ -139,7 +619,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('/'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('/')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
@@ -147,7 +657,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_18
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
@@ -155,7 +695,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_19
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing,
@@ -163,7 +733,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_20
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -176,7 +776,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\",  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((",  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((",  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_21
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False)),
@@ -184,7 +814,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,4.5m,4.6m,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_22
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True)),
@@ -192,7 +852,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.1m,5.0m,(5.0, True))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_23
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False)),
@@ -200,7 +890,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.8m,4.5m,(4.8, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_24
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False)),
@@ -208,7 +928,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.5m,4.5m,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_25
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.\n   --- End of inner exception stack trace ---),
@@ -216,7 +966,43 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.\n   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_26
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.\n   --- End of inner exception stack trace ---),
@@ -224,7 +1010,43 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.\n   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_27
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.,
@@ -232,7 +1054,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_28
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.,
@@ -240,7 +1092,37 @@
             Namespace: UnknownNamespace,
             Type: UnknownType,
             Method: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_29
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -253,7 +1135,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples,
             Type: ExampleTest2(False,null,4,
             Method: 5m,(, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,null,4.5m,(, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,null,4.5m,(, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_30
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -266,7 +1178,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples,
             Type: ExampleTest2(False,4,
             Method: 5m,null,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,4.5m,null,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,null,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_31
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -279,7 +1221,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples,
             Type: ExampleTest2(True,4,
             Method: 3m,null,(4.3, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.3m,null,(4.3, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.3m,null,(4.3, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_32
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -292,7 +1264,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_33
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test,
@@ -300,7 +1302,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_34
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -313,7 +1345,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_35
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test,
@@ -321,7 +1383,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_36
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -334,7 +1426,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_37
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test,
@@ -342,7 +1464,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_38
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -355,7 +1507,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_39
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test,
@@ -363,7 +1545,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_40
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -376,7 +1588,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_41
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -389,7 +1631,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_42
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Answer\",42).Test,
@@ -397,7 +1669,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_43
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -410,7 +1712,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_44
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Question\",1).Test,
@@ -418,7 +1750,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_45
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -431,7 +1793,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_46
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,\"B\"),
@@ -439,7 +1831,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_47
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"A\"),
@@ -447,7 +1869,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_48
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"B\"),
@@ -455,7 +1907,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_49
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"A\"),
@@ -463,7 +1945,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_50
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"B\"),
@@ -471,7 +1983,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_51
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"A\"),
@@ -479,7 +2021,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_52
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"B\"),
@@ -487,7 +2059,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_53
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -500,7 +2102,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_54
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest,
@@ -508,7 +2140,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_55
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest,
@@ -516,7 +2178,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_56
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest,
@@ -524,7 +2216,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_57
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -537,7 +2259,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_58
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest,
@@ -545,7 +2297,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_59
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -558,7 +2340,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_60
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored,
@@ -566,7 +2378,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_61
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive,
@@ -574,7 +2416,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_62
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories,
@@ -582,7 +2454,44 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MultipleCategories,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: MultipleCategories
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_63
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Category2,
+                  Category1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty,
@@ -590,7 +2499,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: NoProperty,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NoProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_64
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11,
@@ -598,7 +2537,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_65
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory,
@@ -606,7 +2575,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategory,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategory
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_66
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Nunit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty,
@@ -614,7 +2619,58 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategoryAndProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_67
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  NUnit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties,
@@ -622,7 +2678,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperties,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value 1
+              },
+              {
+                Key: Property name,
+                Value: Property value 2
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperties
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_68
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value 1
+                  },
+                  {
+                    Key: Property name,
+                    Value: Property value 2
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty,
@@ -630,7 +2739,52 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_69
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11,
@@ -638,7 +2792,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_70
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored,
@@ -646,7 +2830,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_71
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive,
@@ -654,7 +2868,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_72
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11,
@@ -662,7 +2906,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_73
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -675,7 +2949,56 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_74
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22,
@@ -683,7 +3006,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_75
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest,
@@ -691,7 +3050,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_76
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive,
@@ -699,7 +3088,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_77
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21,
@@ -707,7 +3126,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_78
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest,
@@ -715,7 +3170,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_79
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest,
@@ -723,7 +3208,56 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_80
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22,
@@ -731,7 +3265,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_81
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest,
@@ -739,7 +3309,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_82
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive,
@@ -747,7 +3347,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_83
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21,
@@ -755,7 +3385,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_84
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest,
@@ -763,7 +3429,80 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_85
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
+          }
+        ]
+      },
+      {
+        Name: RandomizerTests,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted,
+            DisplayName: Sort_RandomData_IsSorted,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: RandomizerTests,
+            Method: Sort_RandomData_IsSorted,
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_86
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
@@ -11,7 +11,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((, )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((, ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((, ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test)),
@@ -19,7 +49,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((test, test)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((test, test))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\\, \\\\)),
@@ -27,7 +87,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((\\, \\\\)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((\, \\))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\, \\))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\",  )),
@@ -35,7 +125,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((\",  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((",  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((",  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  )),
@@ -43,7 +163,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples(([,  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples(([,  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  )),
@@ -51,7 +201,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest1_Tuples((],  )),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest1_Tuples((],  ))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  ))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,null,4.5m,(, False)),
@@ -59,7 +239,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(False,null,4.5m,(, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,null,4.5m,(, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,null,4.5m,(, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False)),
@@ -67,7 +277,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(False,4.5m,4.6m,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,4.5m,4.6m,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,null,(4.5, False)),
@@ -75,7 +315,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(False,4.5m,null,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(False,4.5m,null,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,null,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.3m,null,(4.3, False)),
@@ -83,7 +353,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(True,4.3m,null,(4.3, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.3m,null,(4.3, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.3m,null,(4.3, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True)),
@@ -91,7 +391,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(True,4.1m,5.0m,(5.0, True)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.1m,5.0m,(5.0, True))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False)),
@@ -99,7 +429,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(True,4.8m,4.5m,(4.8, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.8m,4.5m,(4.8, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False)),
@@ -107,7 +467,37 @@
             Namespace: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly,
             Type: Issue28_Examples,
             Method: ExampleTest2(True,4.5m,4.5m,(4.5, False)),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest2(True,4.5m,4.5m,(4.5, False))
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False))
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0'),
@@ -115,7 +505,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('0'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('0')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a'),
@@ -123,7 +543,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('a'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('a')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A'),
@@ -131,7 +581,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('A'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('A')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!'),
@@ -139,7 +619,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('!'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('!')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-'),
@@ -147,7 +657,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('-'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('-')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_18
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_'),
@@ -155,7 +695,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('_'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('_')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_19
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.'),
@@ -163,7 +733,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('.'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('.')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_20
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*'),
@@ -171,7 +771,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('*'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('*')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_21
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\\''),
@@ -179,7 +809,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('\\''),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_22
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('('),
@@ -187,7 +847,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('('),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('(')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_23
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')'),
@@ -195,7 +885,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3(')'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3(')')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_24
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/'),
@@ -203,7 +923,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('/'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('/')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_25
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
@@ -211,7 +961,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_26
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
@@ -219,7 +999,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_27
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.\n   --- End of inner exception stack trace ---),
@@ -227,7 +1037,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.) ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_28
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.\n   --- End of inner exception stack trace ---),
@@ -235,7 +1081,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.) ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_29
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.,
@@ -243,7 +1125,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_30
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing,
@@ -251,7 +1163,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_31
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -264,7 +1206,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_32
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test,
@@ -272,7 +1244,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_33
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -285,7 +1287,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_34
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test,
@@ -293,7 +1325,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_35
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -306,7 +1368,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_36
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test,
@@ -314,7 +1406,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_37
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -327,7 +1449,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_38
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test,
@@ -335,7 +1487,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_39
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -348,7 +1530,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_40
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input,
@@ -356,7 +1568,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_41
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -369,7 +1611,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_42
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Answer\",42).Test,
@@ -377,7 +1649,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_43
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -390,7 +1692,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_44
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Question\",1).Test,
@@ -398,7 +1730,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_45
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -411,7 +1773,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_46
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,\"B\"),
@@ -419,7 +1811,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_47
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"A\"),
@@ -427,7 +1849,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_48
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"B\"),
@@ -435,7 +1887,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_49
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"A\"),
@@ -443,7 +1925,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_50
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"B\"),
@@ -451,7 +1963,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_51
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"A\"),
@@ -459,7 +2001,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_52
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"B\"),
@@ -467,7 +2039,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_53
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -480,7 +2082,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_54
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest,
@@ -488,7 +2120,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_55
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest,
@@ -496,7 +2158,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_56
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest,
@@ -504,7 +2196,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_57
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -517,7 +2239,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_58
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest,
@@ -525,7 +2277,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_59
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -538,7 +2320,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_60
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored,
@@ -546,7 +2358,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_61
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive,
@@ -554,7 +2396,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_62
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories,
@@ -562,7 +2434,44 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MultipleCategories,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: MultipleCategories
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_63
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Category2,
+                  Category1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty,
@@ -570,7 +2479,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: NoProperty,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NoProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_64
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11,
@@ -578,7 +2517,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_65
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory,
@@ -586,7 +2555,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategory,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategory
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_66
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Nunit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty,
@@ -594,7 +2599,58 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategoryAndProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_67
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  NUnit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties,
@@ -602,7 +2658,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperties,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value 1
+              },
+              {
+                Key: Property name,
+                Value: Property value 2
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperties
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_68
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value 1
+                  },
+                  {
+                    Key: Property name,
+                    Value: Property value 2
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty,
@@ -610,7 +2719,52 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_69
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11,
@@ -618,7 +2772,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_70
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored,
@@ -626,7 +2810,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_71
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive,
@@ -634,7 +2848,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_72
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11,
@@ -642,7 +2886,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_73
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -655,7 +2929,56 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_74
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22,
@@ -663,7 +2986,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_75
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest,
@@ -671,7 +3030,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_76
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive,
@@ -679,7 +3068,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_77
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21,
@@ -687,7 +3106,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_78
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest,
@@ -695,7 +3150,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_79
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest,
@@ -703,7 +3188,56 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_80
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22,
@@ -711,7 +3245,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_81
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest,
@@ -719,7 +3289,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_82
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive,
@@ -727,7 +3327,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_83
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21,
@@ -735,7 +3365,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_84
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest,
@@ -743,7 +3409,80 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_85
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
+          }
+        ]
+      },
+      {
+        Name: RandomizerTests,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted,
+            DisplayName: Sort_RandomData_IsSorted,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: RandomizerTests,
+            Method: Sort_RandomData_IsSorted,
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_86
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetFull.Tests-WindowsOnly.verified.txt
@@ -11,7 +11,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test,
@@ -19,7 +49,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -32,7 +92,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test,
@@ -40,7 +130,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -53,7 +173,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test,
@@ -61,7 +211,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -74,7 +254,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test,
@@ -82,7 +292,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -95,7 +335,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('0'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('0')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a'),
@@ -103,7 +373,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('a'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('a')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A'),
@@ -111,7 +411,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('A'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('A')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!'),
@@ -119,7 +449,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('!'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('!')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-'),
@@ -127,7 +487,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('-'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('-')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_'),
@@ -135,7 +525,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('_'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('_')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.'),
@@ -143,7 +563,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('.'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('.')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*'),
@@ -151,7 +601,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('*'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('*')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\\''),
@@ -159,7 +639,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('\\''),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('('),
@@ -167,7 +677,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('('),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('(')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_18
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')'),
@@ -175,7 +715,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3(')'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3(')')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_19
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/'),
@@ -183,7 +753,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('/'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('/')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_20
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
@@ -191,7 +791,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_21
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
@@ -199,7 +829,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_22
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.\n   --- End of inner exception stack trace ---\n---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---\n),
@@ -207,7 +867,45 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.   --- End of inner exception stack trace ------> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---
+---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---
+)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---
+---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---
+)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_23
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.\n   --- End of inner exception stack trace ---\n---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---\n),
@@ -215,7 +913,45 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.   --- End of inner exception stack trace ------> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---
+---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---
+)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---
+---> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---
+)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_24
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.,
@@ -223,7 +959,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_25
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing,
@@ -231,7 +997,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_26
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -244,7 +1040,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_27
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input,
@@ -252,7 +1078,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_28
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -265,7 +1121,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_29
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Answer\",42).Test,
@@ -273,7 +1159,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_30
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -286,7 +1202,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_31
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Question\",1).Test,
@@ -294,7 +1240,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_32
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -307,7 +1283,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_33
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,\"B\"),
@@ -315,7 +1321,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_34
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"A\"),
@@ -323,7 +1359,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_35
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"B\"),
@@ -331,7 +1397,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_36
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"A\"),
@@ -339,7 +1435,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_37
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"B\"),
@@ -347,7 +1473,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_38
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"A\"),
@@ -355,7 +1511,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_39
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"B\"),
@@ -363,7 +1549,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_40
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -376,7 +1592,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_41
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest,
@@ -384,7 +1630,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_42
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest,
@@ -392,7 +1668,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_43
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest,
@@ -400,7 +1706,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_44
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -413,7 +1749,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_45
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest,
@@ -421,7 +1787,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_46
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -434,7 +1830,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_47
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored,
@@ -442,7 +1868,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_48
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive,
@@ -450,7 +1906,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_49
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories,
@@ -458,7 +1944,44 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MultipleCategories,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: MultipleCategories
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_50
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Category2,
+                  Category1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty,
@@ -466,7 +1989,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: NoProperty,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NoProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_51
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11,
@@ -474,7 +2027,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_52
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory,
@@ -482,7 +2065,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategory,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategory
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_53
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Nunit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty,
@@ -490,7 +2109,58 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategoryAndProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_54
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  NUnit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties,
@@ -498,7 +2168,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperties,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value 1
+              },
+              {
+                Key: Property name,
+                Value: Property value 2
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperties
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_55
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value 1
+                  },
+                  {
+                    Key: Property name,
+                    Value: Property value 2
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty,
@@ -506,7 +2229,52 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_56
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11,
@@ -514,7 +2282,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_57
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored,
@@ -522,7 +2320,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_58
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive,
@@ -530,7 +2358,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_59
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11,
@@ -538,7 +2396,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_60
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -551,7 +2439,56 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_61
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22,
@@ -559,7 +2496,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_62
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest,
@@ -567,7 +2540,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_63
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive,
@@ -575,7 +2578,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_64
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21,
@@ -583,7 +2616,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_65
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest,
@@ -591,7 +2660,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_66
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest,
@@ -599,7 +2698,56 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_67
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22,
@@ -607,7 +2755,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_68
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest,
@@ -615,7 +2799,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_69
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive,
@@ -623,7 +2837,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_70
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21,
@@ -631,7 +2875,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_71
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest,
@@ -639,7 +2919,80 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_72
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
+          }
+        ]
+      },
+      {
+        Name: RandomizerTests,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted,
+            DisplayName: Sort_RandomData_IsSorted,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: RandomizerTests,
+            Method: Sort_RandomData_IsSorted,
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_73
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetMulti.Tests.verified.txt
@@ -11,7 +11,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test,
@@ -19,7 +49,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeSetUp,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -32,7 +92,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test,
@@ -40,7 +130,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingOneTimeTearDown,
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -53,7 +173,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test,
@@ -61,7 +211,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTearDown,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -74,7 +254,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test,
@@ -82,7 +292,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: FailingTestSetup,
             Method: Test,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -95,7 +335,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('0'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('0')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a'),
@@ -103,7 +373,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('a'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('a')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A'),
@@ -111,7 +411,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('A'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('A')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!'),
@@ -119,7 +449,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('!'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('!')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-'),
@@ -127,7 +487,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('-'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('-')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_'),
@@ -135,7 +525,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('_'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('_')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.'),
@@ -143,7 +563,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('.'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('.')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*'),
@@ -151,7 +601,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('*'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('*')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\\''),
@@ -159,7 +639,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('\\''),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('('),
@@ -167,7 +677,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('('),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('(')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_18
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')'),
@@ -175,7 +715,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3(')'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3(')')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_19
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/'),
@@ -183,7 +753,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest3('/'),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest3('/')
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_20
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
@@ -191,7 +791,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_21
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
@@ -199,7 +829,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_22
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.\n   --- End of inner exception stack trace ---),
@@ -207,7 +867,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.) ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_23
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)\n ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.\n   --- End of inner exception stack trace ---),
@@ -215,7 +911,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.) ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.   --- End of inner exception stack trace ---),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value:
+ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value:
+NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
+ ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
+   --- End of inner exception stack trace ---)
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_24
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.,
@@ -223,7 +955,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_25
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing,
@@ -231,7 +993,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: Issue28_Examples,
             Method: Testing,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_26
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -244,7 +1036,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input.,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input.
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_27
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input,
@@ -252,7 +1074,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples,
             Type: Testing,
             Method:  Input,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Testing. Input
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_28
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -265,7 +1117,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_29
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Answer\",42).Test,
@@ -273,7 +1155,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Answer\",42),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_30
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -286,7 +1198,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_31
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture(\"Question\",1).Test,
@@ -294,7 +1236,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedFixture(\"Question\",1),
             Method: Test,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Test
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_32
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -307,7 +1279,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_33
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,\"B\"),
@@ -315,7 +1317,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_34
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"A\"),
@@ -323,7 +1355,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_35
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,\"B\"),
@@ -331,7 +1393,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_36
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"A\"),
@@ -339,7 +1431,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"A\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_37
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,\"B\"),
@@ -347,7 +1469,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(1,\"B\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(1,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_38
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"A\"),
@@ -355,7 +1507,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"A\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"A")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_39
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,\"B\"),
@@ -363,7 +1545,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: ParametrizedTestCases,
             Method: TestData(2,\"B\"),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: TestData(2,"B")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_40
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -376,7 +1588,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_41
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest,
@@ -384,7 +1626,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_42
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest,
@@ -392,7 +1664,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: InconclusiveTest,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: InconclusiveTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_43
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest,
@@ -400,7 +1702,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessAndInconclusiveFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_44
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -413,7 +1745,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_45
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest,
@@ -421,7 +1783,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: SuccessFixture,
             Method: SuccessTest,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: SuccessTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_46
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -434,7 +1826,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_47
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored,
@@ -442,7 +1864,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_48
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive,
@@ -450,7 +1902,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_49
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories,
@@ -458,7 +1940,44 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MultipleCategories,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: MultipleCategories
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_50
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Category2,
+                  Category1
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty,
@@ -466,7 +1985,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: NoProperty,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NoProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_51
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11,
@@ -474,7 +2023,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_52
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory,
@@ -482,7 +2061,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategory,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategory
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_53
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  Nunit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty,
@@ -490,7 +2105,58 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithCategoryAndProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_54
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  NUnit Test Category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties,
@@ -498,7 +2164,60 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperties,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value 1
+              },
+              {
+                Key: Property name,
+                Value: Property value 2
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperties
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_55
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value 1
+                  },
+                  {
+                    Key: Property name,
+                    Value: Property value 2
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty,
@@ -506,7 +2225,52 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: WithProperty,
-            Result: Passed
+            Result: Passed,
+            Traits: [
+              {
+                Key: Property name,
+                Value: Property value
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WithProperty
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_56
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Property name,
+                    Value: Property value
+                  }
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11,
@@ -514,7 +2278,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: FailTest11,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_57
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored,
@@ -522,7 +2316,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Ignored,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Ignored
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_58
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive,
@@ -530,7 +2354,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_59
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11,
@@ -538,7 +2392,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest1,
             Method: PassTest11,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest11
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_60
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -551,7 +2435,56 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_61
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22,
@@ -559,7 +2492,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_62
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest,
@@ -567,7 +2536,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_63
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive,
@@ -575,7 +2574,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_64
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21,
@@ -583,7 +2612,43 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_65
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest,
@@ -591,7 +2656,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_66
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest,
@@ -599,7 +2694,56 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExplicitTest,
-            Result: Skipped
+            Result: Skipped,
+            Traits: [
+              {
+                Key: Explicit,
+                Value: 
+              }
+            ],
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: ExplicitTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_67
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: TestObject.Traits,
+                Value: [
+                  {
+                    Key: Explicit,
+                    Value: 
+                  }
+                ]
+              },
+              {
+                Key: NUnit.Explicit,
+                Value: true
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22,
@@ -607,7 +2751,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: FailTest22,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: FailTest22
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_68
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  failing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest,
@@ -615,7 +2795,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: IgnoredTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: IgnoredTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_69
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive,
@@ -623,7 +2833,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Inconclusive,
-            Result: None
+            Result: None,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Inconclusive
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_70
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21,
@@ -631,7 +2871,43 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: PassTest21,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: PassTest21
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_71
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              },
+              {
+                Key: NUnit.TestCategory,
+                Value: [
+                  passing category
+                ]
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest,
@@ -639,7 +2915,80 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: WarningTest,
-            Result: Skipped
+            Result: Skipped,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: WarningTest
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_72
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
+          }
+        ]
+      },
+      {
+        Name: RandomizerTests,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted,
+            DisplayName: Sort_RandomData_IsSorted,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: RandomizerTests,
+            Method: Sort_RandomData_IsSorted,
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://NUnit3TestExecutor
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_73
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetCore.Tests.verified.txt
@@ -11,7 +11,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -19,7 +49,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -27,7 +87,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -35,7 +125,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -43,7 +163,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -51,7 +201,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -59,7 +239,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -67,7 +277,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -80,7 +320,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -88,7 +358,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -96,7 +396,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -104,7 +434,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -117,7 +477,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -125,7 +515,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -133,7 +553,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -146,7 +596,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -159,7 +639,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -167,7 +677,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -175,7 +715,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetFull.Tests-WindowsOnly.verified.txt
@@ -11,7 +11,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -19,7 +49,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -27,7 +87,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -35,7 +125,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -43,7 +163,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -51,7 +201,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -59,7 +239,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -67,7 +277,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -80,7 +320,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -88,7 +358,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -96,7 +396,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -104,7 +434,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -117,7 +477,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -125,7 +515,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -133,7 +553,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -146,7 +596,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -159,7 +639,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -167,7 +677,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -175,7 +715,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/desktop_and_uap
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: -1
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetMulti.Tests.verified.txt
@@ -11,7 +11,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_1
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -19,7 +49,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_2
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -27,7 +87,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -35,7 +125,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_3
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -43,7 +163,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_4
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -51,7 +201,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_5
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -59,7 +239,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -67,7 +277,37 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_6
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -80,7 +320,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_7
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -88,7 +358,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_8
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -96,7 +396,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_9
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -104,7 +434,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_10
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -117,7 +477,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_11
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -125,7 +515,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_12
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -133,7 +553,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_13
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -146,7 +596,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed
+            Result: Failed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_14
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       },
@@ -159,7 +639,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_15
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -167,7 +677,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_16
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -175,7 +715,37 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed
+            Result: Passed,
+            Properties: [
+              {
+                Key: TestCase.CodeFilePath,
+                Value: null
+              },
+              {
+                Key: TestCase.DisplayName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.ExecutorUri,
+                Value: executor://xunit/VsTestRunner2/netcoreapp
+              },
+              {
+                Key: TestCase.FullyQualifiedName,
+                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
+              },
+              {
+                Key: TestCase.Id,
+                Value: Guid_17
+              },
+              {
+                Key: TestCase.LineNumber,
+                Value: 0
+              },
+              {
+                Key: TestCase.Source,
+                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
+              }
+            ]
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
+++ b/test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
@@ -7,7 +7,7 @@
     <Import Project="$(SourceRoot)scripts/settings.targets" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <WarningsAsErrors>true</WarningsAsErrors>
         <EnableCodeAnalysis>true</EnableCodeAnalysis>
         <IsPackable>false</IsPackable>

--- a/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
+++ b/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
@@ -15,6 +15,7 @@ namespace Spekt.TestLogger.UnitTests.Builders
         private readonly string method = string.Empty;
         private TestOutcome outcome = TestOutcome.Passed;
         private IReadOnlyCollection<Trait> traits = new List<Trait>();
+        private IReadOnlyCollection<KeyValuePair<string, object>> properties = new List<KeyValuePair<string, object>>();
         private string errorMessage = string.Empty;
         private string displayName = string.Empty;
 
@@ -41,6 +42,12 @@ namespace Spekt.TestLogger.UnitTests.Builders
         internal TestResultInfoBuilder WithTraits(IReadOnlyCollection<Trait> traits)
         {
             this.traits = traits;
+            return this;
+        }
+
+        internal TestResultInfoBuilder WithProperties(IReadOnlyCollection<KeyValuePair<string, object>> properties)
+        {
+            this.properties = properties;
             return this;
         }
 
@@ -76,6 +83,7 @@ namespace Spekt.TestLogger.UnitTests.Builders
                 string.Empty,
                 new (),
                 this.traits,
+                this.properties,
                 "executor://dummy");
         }
     }

--- a/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
+++ b/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
@@ -94,6 +94,8 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
                 Type = result.Type,
                 Method = result.Method,
                 Result = result.Outcome.ToString(),
+                Traits = result.Traits.Select(t => new KeyValuePair<string, string>(t.Name, t.Value)).ToList(),
+                Properties = result.Properties.Where(p => p.Key != "NUnit.Seed").ToList() // Skip seed since it changes
             };
         }
 
@@ -137,6 +139,10 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
             public string Method { get; set; }
 
             public string Result { get; set; }
+
+            public List<KeyValuePair<string, string>> Traits { get; set; }
+
+            public List<KeyValuePair<string, object>> Properties { get; set; }
         }
     }
 }

--- a/test/TestLogger.UnitTests/TestLogger.UnitTests.csproj
+++ b/test/TestLogger.UnitTests/TestLogger.UnitTests.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(SourceRoot)scripts/settings.targets" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <WarningsAsErrors>true</WarningsAsErrors>
     <EnableCodeAnalysis>true</EnableCodeAnalysis>
     <IsPackable>false</IsPackable>

--- a/test/TestLogger.UnitTests/TestRunCompleteWorkflowTests.cs
+++ b/test/TestLogger.UnitTests/TestRunCompleteWorkflowTests.cs
@@ -86,7 +86,7 @@ namespace Spekt.TestLogger.UnitTests
             this.testRun.Complete(this.testRunCompleteEvent);
 
             var logFilePath = this.testRun.LoggerConfiguration.LogFilePath;
-            var results = JsonSerializer.Deserialize<JsonTestResultSerializer.TestReport>(this.fileSystem.Read(logFilePath), null);
+            var results = JsonSerializer.Deserialize<JsonTestResultSerializer.TestReport>(this.fileSystem.Read(logFilePath));
             var assembly = results.TestAssemblies.First();
             Assert.AreEqual("/tmp/test.dll", assembly.Name);
             Assert.AreEqual("C", assembly.Fixtures.First().Name);
@@ -119,7 +119,7 @@ namespace Spekt.TestLogger.UnitTests
             this.testRun.Complete(this.testRunCompleteEvent);
 
             var logFilePath = this.testRun.LoggerConfiguration.LogFilePath;
-            var results = JsonSerializer.Deserialize<JsonTestResultSerializer.TestReport>(this.fileSystem.Read(logFilePath), null);
+            var results = JsonSerializer.Deserialize<JsonTestResultSerializer.TestReport>(this.fileSystem.Read(logFilePath));
             var expectedMessages = TestRunMessageEventArgs();
 
             Assert.AreEqual(expectedMessages.Count, results.TestMessages.Count());
@@ -134,10 +134,10 @@ namespace Spekt.TestLogger.UnitTests
             var executorUri = new Uri("executor://dummy");
             var passingResult =
                 new TestResult(new TestCase("NS.C.TM1", executorUri, source))
-                    { Outcome = TestOutcome.Passed };
+                { Outcome = TestOutcome.Passed };
             var failingResult =
                 new TestResult(new TestCase("NS.C.TM2", executorUri, source))
-                    { Outcome = TestOutcome.Failed };
+                { Outcome = TestOutcome.Failed };
             testRun.Result(new TestResultEventArgs(passingResult));
             testRun.Result(new TestResultEventArgs(failingResult));
             TestRunMessageEventArgs().ForEach(x => testRun.Message(x));

--- a/test/assets/Json.TestLogger.NUnit.NetCore.Tests/UnitTest2.cs
+++ b/test/assets/Json.TestLogger.NUnit.NetCore.Tests/UnitTest2.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -188,4 +189,19 @@ namespace NUnit.Xml.TestLogger.Tests2
             Assert.That(s, Is.Not.Null);
         }
     }
+
+	[TestFixture]
+	public class RandomizerTests
+	{
+		[Test]
+		public void Sort_RandomData_IsSorted()
+		{
+			var random = TestContext.CurrentContext.Random;
+			var data = Enumerable.Range(0, 2).Select(i => random.Next()).ToArray();
+
+			Array.Sort(data);
+
+			Assert.That(data, Is.Ordered);
+		}
+	}
 }


### PR DESCRIPTION
NUnit logger requires access to TestProperty for reporting Seed and TestCategory for a test case. See https://github.com/spekt/nunit.testlogger/blob/9efe1add4343d61a6e6d50958751d67acccde965/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs#L282