### PR TITLE
fix: Add DisplayName property in TestResultInfo

### DIFF
--- a/src/TestLogger/Core/TestRunResultWorkflow.cs
+++ b/src/TestLogger/Core/TestRunResultWorkflow.cs
@@ -47,8 +47,8 @@ namespace Spekt.TestLogger.Core
                 sanitize(result.ErrorStackTrace),
                 result.Messages.Select(x => new TestResultMessage(sanitize(x.Category), sanitize(x.Text))).ToList(),
                 result.TestCase.Traits.Select(x => new Trait(sanitize(x.Name), sanitize(x.Value))).ToList(),
-                result.TestCase.Properties.Select(x => new KeyValuePair<string, object>(x.Id, result.TestCase.GetPropertyValue(x))).ToList(), // Cannot sanitize since the value is object (not always string)
-                result.TestCase.ExecutorUri?.ToString()));
+                result.TestCase.ExecutorUri?.ToString(),
+                result.TestCase));
         }
     }
 }

--- a/src/TestLogger/Extensions/NUnitTestAdapter.cs
+++ b/src/TestLogger/Extensions/NUnitTestAdapter.cs
@@ -7,6 +7,7 @@ namespace Spekt.TestLogger.Extensions
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Spekt.TestLogger.Core;
 
     public class NUnitTestAdapter : ITestAdapter
@@ -25,6 +26,22 @@ namespace Spekt.TestLogger.Extensions
                 {
                     result.Outcome = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Skipped;
                 }
+
+                // NUnit adapter uses Seed and TestCategory in TestCase Properties.
+                // Populate these properties if available.
+                var properties = new List<KeyValuePair<string, object>>();
+                foreach (var property in result.TestCase.Properties)
+                {
+                    switch (property.Id)
+                    {
+                        case "NUnit.Seed":
+                        case "NUnit.TestCategory":
+                            properties.Add(new KeyValuePair<string, object>(property.Id, result.TestCase.GetPropertyValue(property)));
+                            break;
+                    }
+                }
+
+                result.Properties = properties;
             }
 
             return results;

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
@@ -11,60 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -72,71 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -144,71 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -216,71 +35,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: ValidateTest3 (PostAsync,),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (GetAsync,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (DeleteAsync,System.Int32),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: ValidateTest4 (PostAsync),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (GetAsync,System.String,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (DeleteAsync,System.Int32),
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -288,71 +107,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -360,71 +115,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -432,71 +123,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -509,75 +136,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is null
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  "ABCDE",
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  3,
-                  null,
-                  null
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -585,75 +144,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is empty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  "",
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  3,
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  ""
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -666,60 +157,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -727,75 +165,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -803,75 +173,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  12,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  30,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -879,75 +181,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  14,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -960,75 +194,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1036,75 +202,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  12,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  30,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1112,75 +210,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  14,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetFull.Tests-WindowsOnly.verified.txt
@@ -11,60 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -72,71 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -144,71 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -216,71 +35,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: ValidateTest3 (PostAsync,),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (GetAsync,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (DeleteAsync,System.Int32),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: ValidateTest4 (PostAsync),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (GetAsync,System.String,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (DeleteAsync,System.Int32),
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -288,71 +107,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -360,71 +115,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -432,71 +123,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -509,75 +136,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is null
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  "ABCDE",
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  3,
-                  null,
-                  null
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -585,75 +144,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is empty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  "",
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  3,
-                  System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  ""
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -666,60 +157,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -727,75 +165,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -803,75 +173,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  12,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  30,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -879,75 +181,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  14,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -960,75 +194,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1036,75 +202,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  12,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  30,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1112,75 +210,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetFull.Tests/bin/Debug/net46/Json.TestLogger.MSTest.NetFull.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  14,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  1,
-                  System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetMulti.Tests.verified.txt
@@ -11,60 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -72,71 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -144,71 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow,
@@ -216,71 +35,71 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: TestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.TestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: TestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: ValidateTest3 (PostAsync,),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (PostAsync,),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (GetAsync,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest3,
+            DisplayName: @RMS-TEST-3 RMS Test 3,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest3 (DeleteAsync,System.Int32),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: ValidateTest4 (PostAsync),
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (PostAsync),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (GetAsync,System.String,System.String),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.ValidateTest4,
+            DisplayName: @RMS-TEST-4 RMS Test 4,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: UnitTest2,
+            Method: ValidateTest4 (DeleteAsync,System.Int32),
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -288,71 +107,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (-1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (-1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  -1
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -360,71 +115,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (0),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  0
-                ]
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow,
@@ -432,71 +123,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: DataTestMethodDataRow (1),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: DataTestMethodDataRow (1)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.DataTestMethodDataRow
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: DataTestMethodDataRow(System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  UnitTest2
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -509,75 +136,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is null,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is null
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  "ABCDE",
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  3,
-                  null,
-                  null
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring,
@@ -585,75 +144,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: When string is empty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName.Substring
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Substring(System.String,System.Int32,System.String)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.Tests2.DataRowWithDisplayName
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.Tests2,
-                  DataRowWithDisplayName
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  "",
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  3,
-                  System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  ""
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -666,60 +157,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: ExampleFailure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleFailure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: ExampleFailure
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -727,75 +165,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -803,75 +173,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  12,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  30,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
@@ -879,75 +181,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Custom - Test_Add (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Custom - Test_Add (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  UnitTest1
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  14,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -960,75 +194,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (1,1,2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  2
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1036,75 +202,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (12,30,42)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  12,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  30,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  42
-                ]
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
@@ -1112,75 +210,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: MathTests,
             Method: Test_Add_DynamicData_Property (14,1,15),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test_Add_DynamicData_Property (14,1,15)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://MSTestAdapter/v2
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.MSTest.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetMulti.Tests.dll
-              },
-              {
-                Key: TestCase.ManagedType,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.ManagedMethod,
-                Value: Test_Add_DynamicData_Property(System.Int32,System.Int32,System.Int32)
-              },
-              {
-                Key: MSTestDiscoverer.TestClassName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.MathTests
-              },
-              {
-                Key: TestCase.Hierarchy,
-                Value: [
-                  NUnit.Xml.TestLogger.NetFull.Tests,
-                  MathTests
-                ]
-              },
-              {
-                Key: TestObject.Traits,
-                Value: []
-              },
-              {
-                Key: MSTest.DynamicDataType,
-                Value: 2
-              },
-              {
-                Key: MSTest.DynamicData,
-                Value: [
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  14,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  1,
-                  System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e,
-                  15
-                ]
-              }
-            ]
+            Result: Failed
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
@@ -14,32 +14,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((, ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((, ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -52,32 +28,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((test, test))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -90,32 +42,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((\, \\))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\, \\))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -128,32 +56,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples(([,  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -166,32 +70,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((],  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -204,32 +84,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('0')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -242,32 +98,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('a')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -280,32 +112,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('A')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -318,32 +126,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('!')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -356,32 +140,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('-')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -394,32 +154,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('_')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -432,32 +168,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('.')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -470,32 +182,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('*')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -508,32 +196,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -546,32 +210,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('(')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -584,32 +224,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3(')')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -622,32 +238,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('/')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -660,32 +252,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_18
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -698,32 +266,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_19
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -736,32 +280,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_20
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -779,32 +299,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((",  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((",  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_21
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -817,32 +313,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,4.5m,4.6m,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_22
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -855,32 +327,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.1m,5.0m,(5.0, True))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_23
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -893,32 +341,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.8m,4.5m,(4.8, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_24
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -931,32 +355,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.5m,4.5m,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_25
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -969,38 +369,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_26
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1013,38 +383,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_27
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1057,32 +397,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_28
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1095,32 +411,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_29
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1138,32 +430,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,null,4.5m,(, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,null,4.5m,(, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_30
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1181,32 +449,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,4.5m,null,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,null,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_31
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1224,32 +468,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.3m,null,(4.3, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.3m,null,(4.3, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_32
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1267,32 +487,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_33
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1305,32 +501,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_34
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1348,32 +520,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_35
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1386,32 +534,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_36
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1429,32 +553,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_37
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1467,32 +567,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_38
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1510,32 +586,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_39
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1548,32 +600,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_40
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1591,32 +619,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_41
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1634,32 +638,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_42
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1672,32 +652,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_43
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1715,32 +671,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_44
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1753,32 +685,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_45
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1796,32 +704,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_46
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1834,32 +718,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_47
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1872,32 +732,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_48
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1910,32 +746,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_49
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1948,32 +760,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_50
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1986,32 +774,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_51
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2024,32 +788,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_52
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2062,32 +802,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_53
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2105,32 +821,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_54
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2143,32 +835,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_55
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2181,32 +849,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_56
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2219,32 +863,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_57
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2262,32 +882,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_58
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2300,32 +896,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_59
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2343,32 +915,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_60
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2381,32 +929,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_61
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2419,32 +943,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_62
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2457,39 +957,15 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: MultipleCategories
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_63
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Category2,
                   Category1
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2502,32 +978,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NoProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_64
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2540,32 +992,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_65
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2578,38 +1006,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategory
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_66
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Nunit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2628,47 +1032,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_67
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   NUnit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2691,45 +1062,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperties
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_68
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value 1
-                  },
-                  {
-                    Key: Property name,
-                    Value: Property value 2
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2748,41 +1082,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_69
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2795,32 +1096,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_70
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2833,32 +1110,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_71
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2871,32 +1124,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_72
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2909,32 +1138,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_73
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2958,45 +1163,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_74
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3009,38 +1177,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_75
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3053,32 +1197,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_76
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3091,32 +1211,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_77
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3129,38 +1225,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_78
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3173,32 +1245,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_79
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3217,45 +1265,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_80
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3268,38 +1279,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_81
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3312,32 +1299,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_82
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3350,32 +1313,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_83
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3388,38 +1327,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_84
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3432,32 +1347,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_85
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -3475,32 +1366,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_86
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
@@ -14,32 +14,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((, ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((, ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -52,32 +28,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((test, test))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((test, test))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -90,32 +42,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((\, \\))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((\, \\))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -128,32 +56,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((",  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((",  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -166,32 +70,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples(([,  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples(([,  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -204,32 +84,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest1_Tuples((],  ))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest1_Tuples((],  ))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -242,32 +98,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,null,4.5m,(, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,null,4.5m,(, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -280,32 +112,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,4.5m,4.6m,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,4.6m,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -318,32 +126,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(False,4.5m,null,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(False,4.5m,null,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -356,32 +140,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.3m,null,(4.3, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.3m,null,(4.3, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -394,32 +154,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.1m,5.0m,(5.0, True))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.1m,5.0m,(5.0, True))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -432,32 +168,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.8m,4.5m,(4.8, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.8m,4.5m,(4.8, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -470,32 +182,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest2(True,4.5m,4.5m,(4.5, False))
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: Json.TestLogger.NUnit.NetCore.Tests.NetCoreOnly.Issue28_Examples.ExampleTest2(True,4.5m,4.5m,(4.5, False))
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -508,32 +196,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('0')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -546,32 +210,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('a')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -584,32 +224,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('A')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -622,32 +238,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('!')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -660,32 +252,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('-')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_18
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -698,32 +266,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('_')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_19
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -736,32 +280,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('.')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_20
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -774,32 +294,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('*')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_21
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -812,32 +308,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_22
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -850,32 +322,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('(')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_23
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -888,32 +336,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3(')')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_24
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -926,32 +350,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('/')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_25
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -964,32 +364,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_26
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1002,32 +378,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_27
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1040,38 +392,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_28
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1084,38 +406,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_29
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1128,32 +420,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_30
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1166,32 +434,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_31
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1209,32 +453,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_32
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1247,32 +467,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_33
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1290,32 +486,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_34
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1328,32 +500,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_35
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1371,32 +519,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_36
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1409,32 +533,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_37
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1452,32 +552,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_38
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1490,32 +566,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_39
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1533,32 +585,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_40
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1571,32 +599,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_41
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1614,32 +618,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_42
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1652,32 +632,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_43
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1695,32 +651,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_44
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1733,32 +665,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_45
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1776,32 +684,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_46
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1814,32 +698,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_47
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1852,32 +712,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_48
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1890,32 +726,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_49
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1928,32 +740,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_50
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1966,32 +754,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_51
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2004,32 +768,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_52
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2042,32 +782,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_53
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2085,32 +801,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_54
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2123,32 +815,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_55
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2161,32 +829,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_56
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2199,32 +843,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_57
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2242,32 +862,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_58
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2280,32 +876,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_59
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2323,32 +895,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_60
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2361,32 +909,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_61
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2399,32 +923,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_62
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2437,39 +937,15 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: MultipleCategories
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_63
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Category2,
                   Category1
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2482,32 +958,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NoProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_64
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2520,32 +972,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_65
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2558,38 +986,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategory
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_66
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Nunit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2608,47 +1012,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_67
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   NUnit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2671,45 +1042,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperties
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_68
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value 1
-                  },
-                  {
-                    Key: Property name,
-                    Value: Property value 2
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2728,41 +1062,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_69
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2775,32 +1076,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_70
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2813,32 +1090,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_71
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2851,32 +1104,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_72
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2889,32 +1118,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_73
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2938,45 +1143,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_74
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2989,38 +1157,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_75
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3033,32 +1177,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_76
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3071,32 +1191,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_77
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3109,38 +1205,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_78
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3153,32 +1225,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_79
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3197,45 +1245,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_80
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3248,38 +1259,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_81
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3292,32 +1279,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_82
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3330,32 +1293,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_83
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3368,38 +1307,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_84
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -3412,32 +1327,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_85
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -3455,32 +1346,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_86
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetCore.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetFull.Tests-WindowsOnly.verified.txt
@@ -14,32 +14,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -52,32 +28,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -95,32 +47,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -133,32 +61,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -176,32 +80,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -214,32 +94,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -257,32 +113,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -295,32 +127,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -338,32 +146,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('0')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -376,32 +160,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('a')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -414,32 +174,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('A')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -452,32 +188,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('!')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -490,32 +202,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('-')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -528,32 +216,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('_')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -566,32 +230,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('.')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -604,32 +244,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('*')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -642,32 +258,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -680,32 +272,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('(')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_18
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -718,32 +286,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3(')')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_19
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -756,32 +300,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('/')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_20
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -794,32 +314,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_21
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -832,32 +328,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_22
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -870,40 +342,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---
----> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---
-)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---
----> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.<---
-)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_23
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -916,40 +356,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---
----> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---
-)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---
----> (Inner Exception #0) NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.<---
-)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_24
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -962,32 +370,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_25
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1000,32 +384,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_26
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1043,32 +403,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_27
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1081,32 +417,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_28
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1124,32 +436,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_29
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1162,32 +450,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_30
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1205,32 +469,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_31
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1243,32 +483,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_32
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1286,32 +502,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_33
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1324,32 +516,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_34
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1362,32 +530,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_35
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1400,32 +544,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_36
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1438,32 +558,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_37
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1476,32 +572,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_38
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1514,32 +586,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_39
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1552,32 +600,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_40
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1595,32 +619,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_41
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1633,32 +633,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_42
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1671,32 +647,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_43
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1709,32 +661,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_44
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1752,32 +680,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_45
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1790,32 +694,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_46
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1833,32 +713,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_47
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1871,32 +727,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_48
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1909,32 +741,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_49
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1947,39 +755,15 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: MultipleCategories
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_50
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Category2,
                   Category1
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1992,32 +776,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NoProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_51
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2030,32 +790,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_52
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2068,38 +804,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategory
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_53
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Nunit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2118,47 +830,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_54
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   NUnit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2181,45 +860,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperties
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_55
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value 1
-                  },
-                  {
-                    Key: Property name,
-                    Value: Property value 2
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2238,41 +880,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_56
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2285,32 +894,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_57
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2323,32 +908,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_58
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2361,32 +922,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_59
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2399,32 +936,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_60
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2448,45 +961,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_61
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2499,38 +975,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_62
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2543,32 +995,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_63
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2581,32 +1009,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_64
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2619,38 +1023,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_65
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2663,32 +1043,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_66
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2707,45 +1063,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_67
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2758,38 +1077,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_68
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2802,32 +1097,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_69
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2840,32 +1111,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_70
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2878,38 +1125,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_71
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2922,32 +1145,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_72
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2965,32 +1164,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_73
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.NUnit.NetFull.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetMulti.Tests.verified.txt
@@ -14,32 +14,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -52,32 +28,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeSetUp.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -95,32 +47,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -133,32 +61,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingOneTimeTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -176,32 +80,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -214,32 +94,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTearDown.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -257,32 +113,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -295,32 +127,8 @@
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.FailingTestSetup.Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -338,32 +146,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('0')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('0')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -376,32 +160,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('a')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('a')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -414,32 +174,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('A')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('A')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -452,32 +188,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('!')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('!')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -490,32 +202,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('-')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('-')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -528,32 +216,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('_')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('_')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -566,32 +230,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('.')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('.')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -604,32 +244,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('*')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('*')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -642,32 +258,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('\'')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -680,32 +272,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('(')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('(')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_18
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -718,32 +286,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3(')')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3(')')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_19
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -756,32 +300,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest3('/')
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest3('/')
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_20
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -794,32 +314,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_21
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -832,32 +328,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_22
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -870,38 +342,8 @@
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException1' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_23
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -914,38 +356,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value:
-ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value:
-NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.AggregateException: One or more errors occurred. (Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.)
- ---> NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2: Exception of type 'NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples+MyException2' was thrown.
-   --- End of inner exception stack trace ---)
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_24
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -958,32 +370,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_25
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -996,32 +384,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_26
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1039,32 +403,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input.
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input.
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_27
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1077,32 +417,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Testing. Input
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.Testing. Input
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_28
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1120,32 +436,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_29
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1158,32 +450,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Answer",42).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_30
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1201,32 +469,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_31
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1239,32 +483,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Test
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedFixture("Question",1).Test
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_32
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1282,32 +502,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_33
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1320,32 +516,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_34
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1358,32 +530,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_35
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1396,32 +544,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_36
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1434,32 +558,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_37
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1472,32 +572,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(1,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(1,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_38
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1510,32 +586,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"A")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"A")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_39
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1548,32 +600,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: TestData(2,"B")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.ParametrizedTestCases.TestData(2,"B")
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_40
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1591,32 +619,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_41
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1629,32 +633,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_42
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1667,32 +647,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: InconclusiveTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.InconclusiveTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_43
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1705,32 +661,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessAndInconclusiveFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_44
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1748,32 +680,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_45
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1786,32 +694,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: SuccessTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.SuccessFixture.SuccessTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_46
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -1829,32 +713,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_47
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1867,32 +727,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_48
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1905,32 +741,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_49
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1943,39 +755,15 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: MultipleCategories
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MultipleCategories
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_50
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Category2,
                   Category1
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -1988,32 +776,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NoProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.NoProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_51
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2026,32 +790,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_52
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2064,38 +804,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategory
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_53
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   Nunit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2114,47 +830,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithCategoryAndProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_54
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   NUnit Test Category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2177,45 +860,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperties
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperties
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_55
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value 1
-                  },
-                  {
-                    Key: Property name,
-                    Value: Property value 2
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2234,41 +880,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WithProperty
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.WithProperty
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_56
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Property name,
-                    Value: Property value
-                  }
-                ]
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2281,32 +894,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.FailTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_57
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2319,32 +908,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Ignored
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Ignored
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_58
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2357,32 +922,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_59
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2395,32 +936,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest11
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest1.PassTest11
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_60
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2444,45 +961,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_61
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2495,38 +975,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_62
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2539,32 +995,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_63
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2577,32 +1009,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_64
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2615,38 +1023,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_65
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2659,32 +1043,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_66
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2703,45 +1063,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             ],
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: ExplicitTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.ExplicitTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_67
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
-                Key: TestObject.Traits,
-                Value: [
-                  {
-                    Key: Explicit,
-                    Value: 
-                  }
-                ]
-              },
-              {
-                Key: NUnit.Explicit,
-                Value: true
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2754,38 +1077,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Failed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: FailTest22
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.FailTest22
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_68
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   failing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2798,32 +1097,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: IgnoredTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.IgnoredTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_69
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2836,32 +1111,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: None,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Inconclusive
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Inconclusive
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_70
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2874,38 +1125,14 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: PassTest21
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.PassTest21
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_71
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
-              },
-              {
                 Key: NUnit.TestCategory,
                 Value: [
                   passing category
                 ]
+              },
+              {
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           },
@@ -2918,32 +1145,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Skipped,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: WarningTest
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.WarningTest
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_72
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }
@@ -2961,32 +1164,8 @@ NUnit.Xml.TestLogger.NetFull.Tests.Issue28_Examples.ExampleTest4(System.Aggregat
             Result: Passed,
             Properties: [
               {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://NUnit3TestExecutor
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.RandomizerTests.Sort_RandomData_IsSorted
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_73
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.NUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.NUnit.NetMulti.Tests.dll
+                Key: NUnit.Seed,
+                Value: 1100
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetCore.Tests.verified.txt
@@ -11,37 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -49,37 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -87,37 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -125,37 +35,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -163,37 +43,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -201,37 +51,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -239,37 +59,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -277,37 +67,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       },
@@ -320,37 +80,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -358,37 +88,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -396,37 +96,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -434,37 +104,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -477,37 +117,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -515,37 +125,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -553,37 +133,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -596,37 +146,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -639,37 +159,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -677,37 +167,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -715,37 +175,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetCore.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetCore.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetFull.Tests-WindowsOnly.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetFull.Tests-WindowsOnly.verified.txt
@@ -11,37 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -49,37 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -87,37 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -125,37 +35,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -163,37 +43,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -201,37 +51,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -239,37 +59,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -277,37 +67,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       },
@@ -320,37 +80,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -358,37 +88,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -396,37 +96,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -434,37 +104,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -477,37 +117,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -515,37 +125,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -553,37 +133,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -596,37 +146,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -639,37 +159,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -677,37 +167,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -715,37 +175,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/desktop_and_uap
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: -1
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetFull.Tests/bin/Debug/net46/Json.TestLogger.XUnit.NetFull.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetMulti.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.XUnit.NetMulti.Tests.verified.txt
@@ -11,37 +11,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_1
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success,
@@ -49,37 +19,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: Example_Success,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Example_Success
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_2
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -87,37 +27,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Foo\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2,
@@ -125,37 +35,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MemberDataTest2(test: ValidationTest2 { Value = \"Bar\" }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MemberDataTest2
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_3
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -163,37 +43,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: \"foo\"),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: "foo")
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_4
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory,
@@ -201,37 +51,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: MyTheory(input: null),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory(input: null)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.MyTheory
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_5
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -239,37 +59,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly,
@@ -277,37 +67,7 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: UnitTest1,
             Method: When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly(test: ValidationTest { }),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.When_ValidOrInvalidDataIsProvided_Then_ValidationErrorsOccurAccordingly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_6
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       },
@@ -320,37 +80,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_7
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -358,37 +88,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_8
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -396,37 +96,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_9
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData,
@@ -434,37 +104,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryClassData,
             Method: CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData(i: -2147483648, j: -1, expected: 2147483647)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryClassData.CanAddTheoryClassData
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_10
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -477,37 +117,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: 1, j: 2, expected: 3)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_11
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -515,37 +125,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -4, j: -6, expected: -10)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_12
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod,
@@ -553,37 +133,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: TheoryMemberData,
             Method: CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0),
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod(i: -2, j: 2, expected: 0)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.TheoryMemberData.CanAddTheoryMemberDataMethod
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_13
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -596,37 +146,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: UnitTest2,
             Method: Example_Failure,
-            Result: Failed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.UnitTest2.Example_Failure
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_14
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Failed
           }
         ]
       },
@@ -639,37 +159,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 2),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 2)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_15
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline,
@@ -677,37 +167,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionAndInline(i: 4),
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline(i: 4)
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionAndInline
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_16
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           },
           {
             FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly,
@@ -715,37 +175,7 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: CollectionTest1,
             Method: CollectionOnly,
-            Result: Passed,
-            Properties: [
-              {
-                Key: TestCase.CodeFilePath,
-                Value: null
-              },
-              {
-                Key: TestCase.DisplayName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.ExecutorUri,
-                Value: executor://xunit/VsTestRunner2/netcoreapp
-              },
-              {
-                Key: TestCase.FullyQualifiedName,
-                Value: NUnit.Xml.TestLogger.Tests2.CollectionTest1.CollectionOnly
-              },
-              {
-                Key: TestCase.Id,
-                Value: Guid_17
-              },
-              {
-                Key: TestCase.LineNumber,
-                Value: 0
-              },
-              {
-                Key: TestCase.Source,
-                Value: test/assets/Json.TestLogger.XUnit.NetMulti.Tests/bin/Debug/netcoreapp3.1/Json.TestLogger.XUnit.NetMulti.Tests.dll
-              }
-            ]
+            Result: Passed
           }
         ]
       }

--- a/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
+++ b/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
@@ -18,6 +18,7 @@ namespace Spekt.TestLogger.UnitTests.Builders
         private IReadOnlyCollection<KeyValuePair<string, object>> properties = new List<KeyValuePair<string, object>>();
         private string errorMessage = string.Empty;
         private string displayName = string.Empty;
+        private TestCase testCase = new TestCase();
 
         internal TestResultInfoBuilder()
         {
@@ -45,9 +46,10 @@ namespace Spekt.TestLogger.UnitTests.Builders
             return this;
         }
 
-        internal TestResultInfoBuilder WithProperties(IReadOnlyCollection<KeyValuePair<string, object>> properties)
+        internal TestResultInfoBuilder WithProperty(string name, object value)
         {
-            this.properties = properties;
+            var p = TestProperty.Register(name, "dummyLabel", value.GetType(), typeof(TestCase));
+            this.testCase.SetPropertyValue(p, value);
             return this;
         }
 
@@ -83,8 +85,8 @@ namespace Spekt.TestLogger.UnitTests.Builders
                 string.Empty,
                 new (),
                 this.traits,
-                this.properties,
-                "executor://dummy");
+                "executor://dummy",
+                this.testCase);
         }
     }
 }

--- a/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
@@ -4,6 +4,7 @@
 namespace Spekt.TestLogger.UnitTests.Extensions
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Spekt.TestLogger.Core;
@@ -74,6 +75,27 @@ namespace Spekt.TestLogger.UnitTests.Extensions
 
             Assert.AreEqual(1, modifiedResults.Count);
             Assert.AreEqual(TestOutcome.Skipped, modifiedResults[0].Outcome);
+        }
+
+        [TestMethod]
+        public void TransformResultShouldAddPropertiesIfAvailable()
+        {
+            var results = new List<TestResultInfo>
+            {
+                new TestResultInfoBuilder(DummyNamespace, DummyType, DummyMethod)
+                    .WithOutcome(TestOutcome.Passed)
+                    .WithProperty("NUnit.Seed", 1)
+                    .WithProperty("NUnit.TestCategory", new[] { "c1", "c2" })
+                    .WithProperty("NUnit.Unsupported", true)
+                    .Build()
+            };
+
+            var modifiedResults = this.adapter.TransformResults(results, new ());
+
+            Assert.AreEqual(1, modifiedResults.Count);
+            Assert.AreEqual(2, modifiedResults[0].Properties.Count);
+            Assert.AreEqual(1, modifiedResults[0].Properties.Where(p => p.Key == "NUnit.Seed").Single().Value);
+            CollectionAssert.AreEquivalent(new[] { "c1", "c2" }, (string[])modifiedResults[0].Properties.Where(p => p.Key == "NUnit.TestCategory").Single().Value);
         }
     }
 }

--- a/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
+++ b/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
@@ -86,16 +86,20 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
 
         private Test CreateTest(TestResultInfo result)
         {
+            var props = result
+                .Properties
+                .Select(p => p.Key == "NUnit.Seed" ? new KeyValuePair<string, object>(p.Key, "1100") : p)
+                .ToList();
             return new ()
             {
                 FullyQualifiedName = result.FullyQualifiedName,
-                DisplayName = result.TestCaseDisplayName,
+                DisplayName = result.DisplayName,
                 Namespace = result.Namespace,
                 Type = result.Type,
                 Method = result.Method,
                 Result = result.Outcome.ToString(),
                 Traits = result.Traits.Select(t => new KeyValuePair<string, string>(t.Name, t.Value)).ToList(),
-                Properties = result.Properties.Where(p => p.Key != "NUnit.Seed").ToList() // Skip seed since it changes
+                Properties = props
             };
         }
 

--- a/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
+++ b/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
@@ -52,6 +52,7 @@ namespace Spekt.TestLogger.UnitTests
             Assert.AreEqual("SampleClass", results[0].Type);
             Assert.AreEqual("SampleNamespace.SampleClass", results[0].FullTypeName);
             Assert.AreEqual("SampleTest", results[0].Method);
+            Assert.AreEqual("SampleNamespace.SampleClass.SampleTest", results[0].DisplayName);
             Assert.AreEqual(DummySourceFile, results[0].AssemblyPath);
 
             Assert.AreEqual(testOutcome, results[0].Outcome);
@@ -64,7 +65,7 @@ namespace Spekt.TestLogger.UnitTests
 
             Assert.AreEqual(0, results[0].Messages.Count);
             Assert.AreEqual(0, results[0].Traits.Count());
-            Assert.AreEqual(7, results[0].Properties.Count());
+            Assert.AreEqual(0, results[0].Properties.Count());
         }
 
         [TestMethod]
@@ -87,6 +88,7 @@ namespace Spekt.TestLogger.UnitTests
         [TestMethod]
         public void ResultShouldCaptureTestProperties()
         {
+            // This property will be ignored.
             var testproperty = TestProperty.Register("TestProperty", "TestLabel", typeof(string), typeof(TestCase));
             this.dummyTestCase.SetPropertyValue(testproperty, "TestValue");
             var resultEvent = new TestResultEventArgs(CreateTestResult(this.dummyTestCase, TestOutcome.Passed));
@@ -95,8 +97,7 @@ namespace Spekt.TestLogger.UnitTests
 
             this.testResultStore.Pop(out var results, out _);
             Assert.AreEqual(1, results.Count);
-            Assert.AreEqual(8, results[0].Properties.Count());
-            CollectionAssert.Contains(results[0].Properties.Select(p => p.Key).ToList(), "TestProperty");
+            Assert.AreEqual(0, results[0].Properties.Count());
         }
 
         private static Dictionary<string, string> BasicConfig()

--- a/test/assets/Json.TestLogger.MSTest.NetCore.Tests/UnitTest2.cs
+++ b/test/assets/Json.TestLogger.MSTest.NetCore.Tests/UnitTest2.cs
@@ -19,7 +19,25 @@ namespace NUnit.Xml.TestLogger.Tests2
         [DataRow(1)]
         public void TestMethodDataRow(int value)
         {
-            Assert.AreEqual(0,value);
+            Assert.AreEqual(0, value);
+        }
+
+        [TestMethod("@RMS-TEST-3 RMS Test 3")]
+        [DataRow("PostAsync", null)]
+        [DataRow("GetAsync", typeof(string))]
+        [DataRow("DeleteAsync", typeof(int))]
+        public void ValidateTest3(string methodName, Type type)
+        {
+            Assert.Fail($"Failed on {methodName}");
+        }
+
+        [TestMethod("@RMS-TEST-4 RMS Test 4")]
+        [DataRow("PostAsync")]
+        [DataRow("GetAsync", typeof(string), typeof(string))]
+        [DataRow("DeleteAsync", typeof(int))]
+        public void ValidateTest4(string methodName, params Type[] extraParams)
+        {
+            Assert.Fail($"Failed on {methodName}");
         }
 
         [DataTestMethod]


### PR DESCRIPTION
* DisplayName represents the test name to be used for reporting by various loggers. Defaults to TestCaseDisplayName. Will be extensible in future: https://github.com/spekt/junit.testlogger/issues/57#issuecomment-1620547408
* Properties collection is now adapter specific; only populated if the test was run by Nunit adapter.