### PR TITLE
feat: Add support for test and run level attachments.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@ ForEach ($local in $($locals -split "`r`n"))
 {
     $local = $local.Substring($local.IndexOf(":") + 2)
     "Deleting from $local"
-    dotnet nuget delete Json.TestLogger 3.0.0-dev --force-english-output --non-interactive -s $local
+    dotnet nuget delete Json.TestLogger 3.1.0-dev --force-english-output --non-interactive -s $local
 }
 
 Remove-Item .\test\package\bin\ -Recurse

--- a/scripts/dependencies.props
+++ b/scripts/dependencies.props
@@ -5,6 +5,7 @@
     <NETTestSdkVersion>16.7.1</NETTestSdkVersion>
     <MoqVersion>4.9.0</MoqVersion>
     <CoverletVersion>2.7.0</CoverletVersion>
+    <CoverletCollectorVersion>3.2.0</CoverletCollectorVersion>
 
     <!-- Test Assets use the minimum supported versions -->
     <NETTestSdkMinimumVersion>15.0.0</NETTestSdkMinimumVersion>

--- a/scripts/settings.targets
+++ b/scripts/settings.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceRoot Condition="$(SourceRoot) == ''">$(MSBuildThisFileDirectory)../../</SourceRoot>
-    <SourcePrefix>3.0.0</SourcePrefix>
+    <SourcePrefix>3.1.0</SourcePrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versioning is defined from the build script. Use a default dev build if it's not defined.

--- a/scripts/version.props
+++ b/scripts/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion Condition="'$(PackageVersion)' == ''">3.0.0-dev</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">3.1.0-dev</PackageVersion>
   </PropertyGroup>
 </Project>
 <!-- vi: set ft=xml: -->

--- a/src/TestLogger/Core/TestAttachmentInfo.cs
+++ b/src/TestLogger/Core/TestAttachmentInfo.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.Core
+{
+    using System;
+
+    /// <summary>
+    /// An attachment for a test suite or a single test.
+    /// </summary>
+    public class TestAttachmentInfo
+    {
+        public TestAttachmentInfo(string filePath, string description)
+        {
+            this.FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            this.Description = description;
+        }
+
+        public string FilePath { get; }
+
+        public string Description { get; }
+    }
+}

--- a/src/TestLogger/Core/TestResultInfo.cs
+++ b/src/TestLogger/Core/TestResultInfo.cs
@@ -26,6 +26,7 @@ namespace Spekt.TestLogger.Core
             string errorMessage,
             string errorStackTrace,
             List<TestResultMessage> messages,
+            List<TestAttachmentInfo> attachments,
             IReadOnlyCollection<Trait> traits,
             string executorUri,
             TestCase testCase)
@@ -46,6 +47,7 @@ namespace Spekt.TestLogger.Core
             this.ErrorMessage = errorMessage;
             this.ErrorStackTrace = errorStackTrace;
             this.Messages = messages;
+            this.Attachments = attachments;
             this.Traits = traits;
             this.ExecutorUri = executorUri;
             this.TestCase = testCase;
@@ -103,6 +105,8 @@ namespace Spekt.TestLogger.Core
         public string ErrorStackTrace { get; }
 
         public List<TestResultMessage> Messages { get; }
+
+        public List<TestAttachmentInfo> Attachments { get; }
 
         /// <summary>
         /// Gets the collection of traits associated with this result.

--- a/src/TestLogger/Core/TestRunCompleteWorkflow.cs
+++ b/src/TestLogger/Core/TestRunCompleteWorkflow.cs
@@ -7,15 +7,18 @@ namespace Spekt.TestLogger.Core
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Security.Cryptography.X509Certificates;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Spekt.TestLogger.Platform;
+    using Spekt.TestLogger.Utilities;
 
     public static class TestRunCompleteWorkflow
     {
         public static void Complete(this ITestRun testRun, TestRunCompleteEventArgs completeEvent)
         {
-            // Update the test run complete timestamp
+            // Update the test run complete timestamp and run level attachments
             testRun.RunConfiguration.EndTime = DateTime.UtcNow;
+            testRun.RunConfiguration.Attachments = completeEvent.AttachmentSets.SelectMany(x => x.ToAttachments()).ToList();
 
             // Freeze and reset the test result store
             testRun.Store.Pop(out var results, out var messages);

--- a/src/TestLogger/Core/TestRunConfiguration.cs
+++ b/src/TestLogger/Core/TestRunConfiguration.cs
@@ -4,6 +4,7 @@
 namespace Spekt.TestLogger.Core
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Configuration for the Test Run.
@@ -27,5 +28,10 @@ namespace Spekt.TestLogger.Core
         /// Gets the end timestamp of test run (test run complete event) in UTC.
         /// </summary>
         public DateTime EndTime { get; internal set; }
+
+        /// <summary>
+        /// Gets the set of run level attachments. E.g., code coverage etc.
+        /// </summary>
+        public IReadOnlyCollection<TestAttachmentInfo> Attachments { get; internal set; }
     }
 }

--- a/src/TestLogger/Core/TestRunResultWorkflow.cs
+++ b/src/TestLogger/Core/TestRunResultWorkflow.cs
@@ -9,6 +9,7 @@ namespace Spekt.TestLogger.Core
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
     using Spekt.TestLogger.Extensions;
+    using Spekt.TestLogger.Utilities;
 
     public static class TestRunResultWorkflow
     {
@@ -46,6 +47,7 @@ namespace Spekt.TestLogger.Core
                 sanitize(result.ErrorMessage),
                 sanitize(result.ErrorStackTrace),
                 result.Messages.Select(x => new TestResultMessage(sanitize(x.Category), sanitize(x.Text))).ToList(),
+                result.Attachments.SelectMany(x => x.ToAttachments()).ToList(),
                 result.TestCase.Traits.Select(x => new Trait(sanitize(x.Name), sanitize(x.Value))).ToList(),
                 result.TestCase.ExecutorUri?.ToString(),
                 result.TestCase));

--- a/src/TestLogger/Utilities/AttachmentSetExtensions.cs
+++ b/src/TestLogger/Utilities/AttachmentSetExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Spekt.TestLogger.Core;
+
+    public static class AttachmentSetExtensions
+    {
+        public static IEnumerable<TestAttachmentInfo> ToAttachments(this AttachmentSet attachmentSet)
+        {
+            return attachmentSet.Attachments.Select(a => new
+                    TestAttachmentInfo(GetPathFromUri(a.Uri), a.Description));
+        }
+
+        private static string GetPathFromUri(Uri uri)
+        {
+            try
+            {
+                return uri.LocalPath;
+            }
+            catch (InvalidOperationException)
+            {
+                return uri.OriginalString;
+            }
+        }
+    }
+}

--- a/test/TestLogger.AcceptanceTests/DotnetTestFixture.cs
+++ b/test/TestLogger.AcceptanceTests/DotnetTestFixture.cs
@@ -12,7 +12,7 @@ namespace TestLogger.AcceptanceTests
         private const string NetcoreVersion = "netcoreapp3.1";
         private const string ResultFile = "test-results.json";
 
-        public static void Execute(string assemblyName, string args, out string resultsFile)
+        public static void Execute(string assemblyName, string args, bool collectCoverage, out string resultsFile)
         {
             resultsFile = Path.Combine(GetAssemblyPath(assemblyName), "test-results.json");
             if (File.Exists(resultsFile))
@@ -45,6 +45,12 @@ namespace TestLogger.AcceptanceTests
                     Arguments = $"test --no-build --logger:\"json;LogFilePath={ResultFile}{args}\" {GetAssemblyPath(assemblyName)}\\{assemblyName}.csproj"
                 }
             };
+
+            // Add coverage arg if required
+            if (collectCoverage)
+            {
+                dotnet.StartInfo.Arguments += " --collect:\"XPlat Code Coverage\" --settings coverlet.runsettings";
+            }
 
             // Required to skip icu requirement for netcoreapp3.1 in linux
             dotnet.StartInfo.EnvironmentVariables["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1";

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
@@ -3,6 +3,91 @@
     Name: bin/Debug/netcoreapp3.1/Json.TestLogger.MSTest.NetCore.Tests.dll,
     Fixtures: [
       {
+        Name: UnitTest1,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure,
+            DisplayName: ExampleFailure,
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: UnitTest1,
+            Method: ExampleFailure,
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
+            DisplayName: Custom - Test_Add (1,1,2),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: UnitTest1,
+            Method: Custom - Test_Add (1,1,2),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
+            DisplayName: Custom - Test_Add (12,30,42),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: UnitTest1,
+            Method: Custom - Test_Add (12,30,42),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
+            DisplayName: Custom - Test_Add (14,1,15),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: UnitTest1,
+            Method: Custom - Test_Add (14,1,15),
+            Result: Failed
+          }
+        ]
+      },
+      {
+        Name: MathTests,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
+            DisplayName: Test_Add_DynamicData_Property (1,1,2),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: MathTests,
+            Method: Test_Add_DynamicData_Property (1,1,2),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
+            DisplayName: Test_Add_DynamicData_Property (12,30,42),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: MathTests,
+            Method: Test_Add_DynamicData_Property (12,30,42),
+            Result: Failed
+          },
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
+            DisplayName: Test_Add_DynamicData_Property (14,1,15),
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: MathTests,
+            Method: Test_Add_DynamicData_Property (14,1,15),
+            Result: Failed
+          }
+        ]
+      },
+      {
+        Name: AttachmentTest,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.Tests2.AttachmentTest.TestAddAttachment,
+            DisplayName: TestAddAttachment,
+            Namespace: NUnit.Xml.TestLogger.Tests2,
+            Type: AttachmentTest,
+            Method: TestAddAttachment,
+            Result: Passed,
+            Attachments: [
+              {
+                FilePath: {TempPath}x.txt,
+                Description: {TempPath}x.txt
+              }
+            ]
+          }
+        ]
+      },
+      {
         Name: UnitTest2,
         Tests: [
           {
@@ -144,72 +229,6 @@
             Namespace: NUnit.Xml.TestLogger.Tests2,
             Type: DataRowWithDisplayName,
             Method: When string is empty,
-            Result: Failed
-          }
-        ]
-      },
-      {
-        Name: UnitTest1,
-        Tests: [
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.ExampleFailure,
-            DisplayName: ExampleFailure,
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: UnitTest1,
-            Method: ExampleFailure,
-            Result: Failed
-          },
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
-            DisplayName: Custom - Test_Add (1,1,2),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: UnitTest1,
-            Method: Custom - Test_Add (1,1,2),
-            Result: Failed
-          },
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
-            DisplayName: Custom - Test_Add (12,30,42),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: UnitTest1,
-            Method: Custom - Test_Add (12,30,42),
-            Result: Failed
-          },
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.UnitTest1.Test_Add,
-            DisplayName: Custom - Test_Add (14,1,15),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: UnitTest1,
-            Method: Custom - Test_Add (14,1,15),
-            Result: Failed
-          }
-        ]
-      },
-      {
-        Name: MathTests,
-        Tests: [
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
-            DisplayName: Test_Add_DynamicData_Property (1,1,2),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: MathTests,
-            Method: Test_Add_DynamicData_Property (1,1,2),
-            Result: Failed
-          },
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
-            DisplayName: Test_Add_DynamicData_Property (12,30,42),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: MathTests,
-            Method: Test_Add_DynamicData_Property (12,30,42),
-            Result: Failed
-          },
-          {
-            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.MathTests.Test_Add_DynamicData_Property,
-            DisplayName: Test_Add_DynamicData_Property (14,1,15),
-            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
-            Type: MathTests,
-            Method: Test_Add_DynamicData_Property (14,1,15),
             Result: Failed
           }
         ]

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
@@ -81,7 +81,7 @@
             Attachments: [
               {
                 FilePath: x.txt,
-                Description: {TempPath}x.txt
+                Description: dummyDescription
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.MSTest.NetCore.Tests.verified.txt
@@ -80,7 +80,7 @@
             Result: Passed,
             Attachments: [
               {
-                FilePath: {TempPath}x.txt,
+                FilePath: x.txt,
                 Description: {TempPath}x.txt
               }
             ]

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
@@ -494,7 +494,7 @@
             Attachments: [
               {
                 FilePath: x.txt,
-                Description: x
+                Description: dummyDescription
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
@@ -476,6 +476,25 @@
         ]
       },
       {
+        Name: AttachmentTest,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.AttachmentTest.TestAddAttachment,
+            DisplayName: TestAddAttachment,
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: AttachmentTest,
+            Method: TestAddAttachment,
+            Result: Failed,
+            Properties: [
+              {
+                Key: NUnit.Seed,
+                Value: 1100
+              }
+            ]
+          }
+        ]
+      },
+      {
         Name: FailingOneTimeSetUp,
         Tests: [
           {

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests-;Parser=Legacy-IncludesParserFailures.verified.txt
@@ -484,11 +484,17 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: AttachmentTest,
             Method: TestAddAttachment,
-            Result: Failed,
+            Result: Passed,
             Properties: [
               {
                 Key: NUnit.Seed,
                 Value: 1100
+              }
+            ],
+            Attachments: [
+              {
+                FilePath: x.txt,
+                Description: x
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
@@ -442,6 +442,25 @@
         ]
       },
       {
+        Name: AttachmentTest,
+        Tests: [
+          {
+            FullyQualifiedName: NUnit.Xml.TestLogger.NetFull.Tests.AttachmentTest.TestAddAttachment,
+            DisplayName: TestAddAttachment,
+            Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
+            Type: AttachmentTest,
+            Method: TestAddAttachment,
+            Result: Failed,
+            Properties: [
+              {
+                Key: NUnit.Seed,
+                Value: 1100
+              }
+            ]
+          }
+        ]
+      },
+      {
         Name: FailingOneTimeSetUp,
         Tests: [
           {

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
@@ -450,11 +450,17 @@
             Namespace: NUnit.Xml.TestLogger.NetFull.Tests,
             Type: AttachmentTest,
             Method: TestAddAttachment,
-            Result: Failed,
+            Result: Passed,
             Properties: [
               {
                 Key: NUnit.Seed,
                 Value: 1100
+              }
+            ],
+            Attachments: [
+              {
+                FilePath: x.txt,
+                Description: x
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
+++ b/test/TestLogger.AcceptanceTests/Snapshots/TestLoggerAcceptanceTests/VerifyTestRunOutput/Json.TestLogger.NUnit.NetCore.Tests.verified.txt
@@ -460,7 +460,7 @@
             Attachments: [
               {
                 FilePath: x.txt,
-                Description: x
+                Description: dummyDescription
               }
             ]
           }

--- a/test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
+++ b/test/TestLogger.AcceptanceTests/TestLogger.AcceptanceTests.csproj
@@ -51,4 +51,9 @@
     <ItemGroup>
         <ProjectReference Include="..\Json.TestLogger.TestAdapter\Json.TestLogger.TestAdapter.csproj" />
     </ItemGroup>
+    <ItemGroup>
+        <Content Include="coverlet.runsettings">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>  
+    </ItemGroup>
 </Project>

--- a/test/TestLogger.AcceptanceTests/TestLoggerAcceptanceTests.cs
+++ b/test/TestLogger.AcceptanceTests/TestLoggerAcceptanceTests.cs
@@ -83,7 +83,9 @@ namespace TestLogger.AcceptanceTests
                 return x;
             });
 
-            DotnetTestFixture.Execute(testAssembly, args, out var resultsFile);
+            // Collect coverage will attach a runlevel attachment.
+            var collectCoverage = testAssembly.Contains("XUnit.NetCore");
+            DotnetTestFixture.Execute(testAssembly, args, collectCoverage, out var resultsFile);
             var testReport = JsonConvert.DeserializeObject<TestReport>(File.ReadAllText(resultsFile));
 
             return this.Verify(testReport.TestAssemblies, settings);

--- a/test/TestLogger.AcceptanceTests/coverlet.runsettings
+++ b/test/TestLogger.AcceptanceTests/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[coverlet.*.tests?]*,[*]Coverlet.Core*,[*Spekt*]*,[*TestLogger*]*</Exclude> <!-- [Assembly-Filter]Type-Filter -->
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
+++ b/test/TestLogger.UnitTests/Builders/TestResultInfoBuilder.cs
@@ -15,10 +15,10 @@ namespace Spekt.TestLogger.UnitTests.Builders
         private readonly string method = string.Empty;
         private TestOutcome outcome = TestOutcome.Passed;
         private IReadOnlyCollection<Trait> traits = new List<Trait>();
-        private IReadOnlyCollection<KeyValuePair<string, object>> properties = new List<KeyValuePair<string, object>>();
         private string errorMessage = string.Empty;
         private string displayName = string.Empty;
         private TestCase testCase = new TestCase();
+        private List<TestAttachmentInfo> attachments = new ();
 
         internal TestResultInfoBuilder()
         {
@@ -65,6 +65,12 @@ namespace Spekt.TestLogger.UnitTests.Builders
             return this;
         }
 
+        internal TestResultInfoBuilder WithAttachment(TestAttachmentInfo attachment)
+        {
+            this.attachments.Add(attachment);
+            return this;
+        }
+
         internal TestResultInfo Build()
         {
             return new TestResultInfo(
@@ -84,6 +90,7 @@ namespace Spekt.TestLogger.UnitTests.Builders
                 this.errorMessage,
                 string.Empty,
                 new (),
+                this.attachments,
                 this.traits,
                 "executor://dummy",
                 this.testCase);

--- a/test/TestLogger.UnitTests/TestAttachmentInfoTests.cs
+++ b/test/TestLogger.UnitTests/TestAttachmentInfoTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.UnitTests
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Spekt.TestLogger.Core;
+
+    [TestClass]
+    public class TestAttachmentInfoTests
+    {
+        [TestMethod]
+        public void TestAttachmentInfoShouldThrowForNullFilePath()
+        {
+            var action = () => new TestAttachmentInfo(null, "description");
+
+            Assert.ThrowsException<ArgumentNullException>(action);
+        }
+    }
+}

--- a/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
+++ b/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
@@ -60,7 +60,7 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
                 select this.CreateAssembly(assemblies);
 
             var content = new StringBuilder();
-            new JsonSerializer().Serialize(new StringWriter(content), new TestReport(res, messages));
+            new JsonSerializer().Serialize(new StringWriter(content), new TestReport(res, messages, runConfiguration.Attachments));
             return content.ToString();
         }
 
@@ -99,21 +99,29 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
                 Method = result.Method,
                 Result = result.Outcome.ToString(),
                 Traits = result.Traits.Select(t => new KeyValuePair<string, string>(t.Name, t.Value)).ToList(),
-                Properties = props
+                Properties = props,
+                Attachments = result.Attachments
             };
         }
 
         public class TestReport
         {
-            public TestReport(IEnumerable<TestAssembly> testAssemblies, IEnumerable<TestMessageInfo> testMessages)
+            public TestReport(IEnumerable<TestAssembly> testAssemblies, IEnumerable<TestMessageInfo> testMessages, IReadOnlyCollection<TestAttachmentInfo> attachments)
             {
                 this.TestAssemblies = testAssemblies ?? throw new ArgumentNullException(nameof(testAssemblies));
                 this.TestMessages = testMessages ?? throw new ArgumentNullException(nameof(testMessages));
+
+                // Mangle attachments to predictable filepath
+                this.Attachments = attachments
+                    .Select(a => new TestAttachmentInfo(Path.GetFileName(a.FilePath), a.Description))
+                    .ToList();
             }
 
             public IEnumerable<TestAssembly> TestAssemblies { get; set; }
 
             public IEnumerable<TestMessageInfo> TestMessages { get; set; }
+
+            public IReadOnlyCollection<TestAttachmentInfo> Attachments { get; set; }
         }
 
         public class TestAssembly
@@ -147,6 +155,8 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
             public List<KeyValuePair<string, string>> Traits { get; set; }
 
             public List<KeyValuePair<string, object>> Properties { get; set; }
+
+            public List<TestAttachmentInfo> Attachments { get; set; }
         }
     }
 }

--- a/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
+++ b/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
@@ -86,9 +86,13 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
 
         private Test CreateTest(TestResultInfo result)
         {
+            // Mangle output to ensure predictable report
             var props = result
                 .Properties
                 .Select(p => p.Key == "NUnit.Seed" ? new KeyValuePair<string, object>(p.Key, "1100") : p)
+                .ToList();
+            var attachments = result.Attachments
+                .Select(a => new TestAttachmentInfo(Path.GetFileName(a.FilePath), a.Description))
                 .ToList();
             return new ()
             {
@@ -100,7 +104,7 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
                 Result = result.Outcome.ToString(),
                 Traits = result.Traits.Select(t => new KeyValuePair<string, string>(t.Name, t.Value)).ToList(),
                 Properties = props,
-                Attachments = result.Attachments
+                Attachments = attachments
             };
         }
 

--- a/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
+++ b/test/TestLogger.UnitTests/TestDoubles/JsonTestResultSerializer.cs
@@ -91,8 +91,11 @@ namespace Spekt.TestLogger.UnitTests.TestDoubles
                 .Properties
                 .Select(p => p.Key == "NUnit.Seed" ? new KeyValuePair<string, object>(p.Key, "1100") : p)
                 .ToList();
+
+            // Attachments have diff path in Windows vs Linux.
+            // MSTest duplicates the path in description.
             var attachments = result.Attachments
-                .Select(a => new TestAttachmentInfo(Path.GetFileName(a.FilePath), a.Description))
+                .Select(a => new TestAttachmentInfo(Path.GetFileName(a.FilePath), "dummyDescription"))
                 .ToList();
             return new ()
             {

--- a/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
+++ b/test/TestLogger.UnitTests/TestRunResultWorkflowTests.cs
@@ -64,8 +64,9 @@ namespace Spekt.TestLogger.UnitTests
             Assert.AreEqual(DateTimeOffset.MaxValue, results[0].EndTime);
 
             Assert.AreEqual(0, results[0].Messages.Count);
-            Assert.AreEqual(0, results[0].Traits.Count());
-            Assert.AreEqual(0, results[0].Properties.Count());
+            Assert.AreEqual(0, results[0].Traits.Count);
+            Assert.AreEqual(0, results[0].Properties.Count);
+            Assert.AreEqual(0, results[0].Attachments.Count);
         }
 
         [TestMethod]
@@ -97,7 +98,7 @@ namespace Spekt.TestLogger.UnitTests
 
             this.testResultStore.Pop(out var results, out _);
             Assert.AreEqual(1, results.Count);
-            Assert.AreEqual(0, results[0].Properties.Count());
+            Assert.AreEqual(0, results[0].Properties.Count);
         }
 
         private static Dictionary<string, string> BasicConfig()

--- a/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
+++ b/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Spekt.TestLogger.UnitTests.Utilities
         [TestMethod]
         public void ToAttachmentsShouldConvertLocalPaths()
         {
-            this.attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("/tmp/x.txt"), "x"));
+            this.attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("file:///tmp/x.txt"), "x"));
 
             var attachments = this.attachmentSet.ToAttachments().ToArray();
 

--- a/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
+++ b/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
@@ -30,5 +30,17 @@ namespace Spekt.TestLogger.UnitTests.Utilities
             Assert.AreEqual("/tmp/x.txt", attachments[0].FilePath);
             Assert.AreEqual("x", attachments[0].Description);
         }
+
+        [TestMethod]
+        public void ToAttachmentsShouldReturnOriginalStringIfPathIsNotWellformed()
+        {
+            this.attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("/tmp/x.txt", UriKind.Relative), "x"));
+
+            var attachments = this.attachmentSet.ToAttachments().ToArray();
+
+            Assert.AreEqual(1, attachments.Length);
+            Assert.AreEqual("/tmp/x.txt", attachments[0].FilePath);
+            Assert.AreEqual("x", attachments[0].Description);
+        }
     }
 }

--- a/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
+++ b/test/TestLogger.UnitTests/Utilities/AttachmentSetExtensionsTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Spekt.TestLogger.UnitTests.Utilities
+{
+    using System;
+    using System.Linq;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Spekt.TestLogger.Utilities;
+
+    [TestClass]
+    public class AttachmentSetExtensionsTests
+    {
+        private readonly AttachmentSet attachmentSet;
+
+        public AttachmentSetExtensionsTests()
+        {
+            this.attachmentSet = new AttachmentSet(new Uri("//dummyUri"), "dummyDescription");
+        }
+
+        [TestMethod]
+        public void ToAttachmentsShouldConvertLocalPaths()
+        {
+            this.attachmentSet.Attachments.Add(new UriDataAttachment(new Uri("/tmp/x.txt"), "x"));
+
+            var attachments = this.attachmentSet.ToAttachments().ToArray();
+
+            Assert.AreEqual(1, attachments.Length);
+            Assert.AreEqual("/tmp/x.txt", attachments[0].FilePath);
+            Assert.AreEqual("x", attachments[0].Description);
+        }
+    }
+}

--- a/test/assets/Json.TestLogger.MSTest.NetCore.Tests/AttachmentTest.cs
+++ b/test/assets/Json.TestLogger.MSTest.NetCore.Tests/AttachmentTest.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NUnit.Xml.TestLogger.Tests2
+{
+    [TestClass]
+    public class AttachmentTest
+    {
+        public TestContext TestContext { get; set; }
+        
+        [TestMethod]
+        public void TestAddAttachment()
+        {
+            TestContext.AddResultFile("/tmp/x.txt");
+        }
+    }
+}

--- a/test/assets/Json.TestLogger.NUnit.NetCore.Tests/AttachmentTest.cs
+++ b/test/assets/Json.TestLogger.NUnit.NetCore.Tests/AttachmentTest.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NUnit.Xml.TestLogger.NetFull.Tests
+{
+    [TestFixture]
+    public class AttachmentTest
+    {
+        [Test]
+        public void TestAddAttachment()
+        {
+            TestContext.AddTestAttachment("/tmp/x.txt", "/tmp/x.txt");
+        }
+    }
+}

--- a/test/assets/Json.TestLogger.NUnit.NetCore.Tests/AttachmentTest.cs
+++ b/test/assets/Json.TestLogger.NUnit.NetCore.Tests/AttachmentTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -12,7 +13,12 @@ namespace NUnit.Xml.TestLogger.NetFull.Tests
         [Test]
         public void TestAddAttachment()
         {
-            TestContext.AddTestAttachment("/tmp/x.txt", "/tmp/x.txt");
+            var filePath = Path.Combine(Path.GetTempPath(), "x.txt");
+            if (!File.Exists(filePath))
+            {
+                File.Create(filePath);
+            }
+            TestContext.AddTestAttachment(filePath, "x");
         }
     }
 }

--- a/test/assets/Json.TestLogger.XUnit.NetCore.Tests/Json.TestLogger.XUnit.NetCore.Tests.csproj
+++ b/test/assets/Json.TestLogger.XUnit.NetCore.Tests/Json.TestLogger.XUnit.NetCore.Tests.csproj
@@ -13,13 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(NETTestSdkMinimumVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(NETTestSdkVersion)" />
     <PackageReference Include="XUnit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitTestAdapterVersion)" />
     <PackageReference Include="Json.TestLogger" Version="$(PackageVersion)" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Coverlet.Collector" Version="$(CoverletCollectorVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Core testlogger can now report Attachments on a per test (via TestResultInfo) and per run (via Serialize()). Update version to 3.1.x.