### PR TITLE
Nested classes report UnknownNamespace.UnknownMethod

### DIFF
--- a/src/TestLogger/Core/TestCaseNameParser.cs
+++ b/src/TestLogger/Core/TestCaseNameParser.cs
@@ -24,7 +24,7 @@ namespace Spekt.TestLogger.Core
         /// <summary>
         /// This one can handle standard formatting with or without method data.
         /// </summary>
-        private static readonly Regex MethodRegex = new (@"^([a-z0-9_.]{1,})\.([a-z0-9_.]{1,})\.(.{1,})$", RegexOptions);
+        private static readonly Regex MethodRegex = new (@"^([a-z0-9_.]{1,})\.([a-z0-9_.+]{1,})\.(.{1,})$", RegexOptions);
 
         /// <summary>
         /// Can handle standard formatting with class and method data.

--- a/test/TestLogger.UnitTests/TestCaseNameParserTests.cs
+++ b/test/TestLogger.UnitTests/TestCaseNameParserTests.cs
@@ -46,6 +46,9 @@ namespace Spekt.TestLogger.UnitTests
         [DataRow("z.y.x.ape.bar('\\'',False)", "z.y.x", "ape", "bar('\\'',False)")]
         [DataRow("z.y.x.ape.bar('\\\\',False)", "z.y.x", "ape", "bar('\\\\',False)")]
 
+        // See xunit.testlogger #48
+        [DataRow("z.y+a.x", "z", "y+a", "x")]
+
         // Strip out any line breaks
         [DataRow("z.y.x.ape.bar('aa\r\nbb',False)", "z.y.x", "ape", "bar('aabb',False)")]
         [DataRow("z.y.x.ape.bar('aa\nbb',False)", "z.y.x", "ape", "bar('aabb',False)")]


### PR DESCRIPTION
Fixes https://github.com/spekt/xunit.testlogger/issues/48

Updated regex to handle nested class scenario as classes use + as a separator
Added test case