### PR TITLE
fix: standardize the start and end time formats in nunit report.

### DIFF
--- a/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
+++ b/src/NUnit.Xml.TestLogger/NUnitXmlSerializer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.NUnit.Xml.TestLogger
 
     public class NUnitXmlSerializer : ITestResultSerializer
     {
-        private const string DateFormat = "yyyy-MM-ddT HH:mm:ssZ";
+        private const string DateFormat = "yyyy-MM-ddTHH:mm:ssZ";
         private const string ResultStatusPassed = "Passed";
         private const string ResultStatusFailed = "Failed";
 

--- a/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
+++ b/test/NUnit.Xml.TestLogger.AcceptanceTests/NUnitTestLoggerAcceptanceTests.cs
@@ -177,7 +177,7 @@ namespace NUnit.Xml.TestLogger.AcceptanceTests
             Assert.IsNotNull(startTimeStr);
             Assert.IsNotNull(endTimeStr);
 
-            string dateFormat = "yyyy-MM-ddT HH:mm:ssZ";
+            string dateFormat = "yyyy-MM-ddTHH:mm:ssZ";
             var startTime = DateTime.ParseExact(startTimeStr, dateFormat, CultureInfo.InvariantCulture);
             var endTime = DateTime.ParseExact(endTimeStr, dateFormat, CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
Fixes https://github.com/spekt/nunit.testlogger/issues/105