### PR TITLE
feat: [junit] #153 Add properties support on test case level for test logger

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "3.1.x"
+      - name: Configure NuGet cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Package (debug)
         run: dotnet pack -p:PackageVersion=${{ env.APP_BUILD_VERSION }}
       - name: Package (release)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,6 +45,9 @@ jobs:
     needs: [version]
     env:
       APP_BUILD_VERSION: ${{ needs.version.outputs.build_version }}
+      # force color output for dotnet
+      DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1"
+      TERM: "xterm"
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET 8.0

--- a/src/TestLogger/Extensions/MSTestAdapter.cs
+++ b/src/TestLogger/Extensions/MSTestAdapter.cs
@@ -29,6 +29,21 @@ namespace Spekt.TestLogger.Extensions
                 {
                     result.Method = displayName;
                 }
+
+                // Parse property traits
+                var properties = new List<KeyValuePair<string, object>>();
+                foreach (var property in result.TestCase.Properties)
+                {
+                    switch (property.Id)
+                    {
+                        case "Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestProperty":
+                            var propertyValue = result.TestCase.GetPropertyValue(property) as string[];
+                            properties.Add(new KeyValuePair<string, object>("CustomProperty", propertyValue));
+                            break;
+                    }
+                }
+
+                result.Properties = properties;
             }
 
             return results;

--- a/src/TestLogger/Extensions/NUnitTestAdapter.cs
+++ b/src/TestLogger/Extensions/NUnitTestAdapter.cs
@@ -38,6 +38,9 @@ namespace Spekt.TestLogger.Extensions
                         case "NUnit.TestCategory":
                             properties.Add(new KeyValuePair<string, object>(property.Id, result.TestCase.GetPropertyValue(property)));
                             break;
+                        case "NUnit.Category":
+                            properties.Add(new KeyValuePair<string, object>("CustomProperty", result.TestCase.GetPropertyValue(property)));
+                            break;
                     }
                 }
 

--- a/src/TestLogger/Extensions/XunitTestAdapter.cs
+++ b/src/TestLogger/Extensions/XunitTestAdapter.cs
@@ -56,6 +56,23 @@ namespace Spekt.TestLogger.Extensions
                     result.Method += displayName.Substring(i);
                 }
 
+                var properties = new List<KeyValuePair<string, object>>();
+
+                // Parse test traits via Trait decorator
+                foreach (var property in result.TestCase.Properties)
+                {
+                    switch (property.Id)
+                    {
+                        case "Xunit.Trait":
+                            var propertyValue = result.TestCase.GetPropertyValue(property) as string[];
+
+                            properties.Add(new KeyValuePair<string, object>("CustomProperty", propertyValue));
+                            break;
+                    }
+                }
+
+                result.Properties = properties;
+
                 transformedResults.Add(result);
             }
 

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnit.Xml.TestLogger.AcceptanceTests.csproj
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnit.Xml.TestLogger.AcceptanceTests.csproj
@@ -27,6 +27,7 @@
 
     <TestAssets Include="$(MSBuildThisFileDirectory)../assets/JUnit.Xml.TestLogger.NetCore.Tests/JUnit.Xml.TestLogger.NetCore.Tests.csproj" />
     <TestAssets Include="$(MSBuildThisFileDirectory)../assets/JUnit.Xml.TestLogger.NetMulti.Tests/JUnit.Xml.TestLogger.NetMulti.Tests.csproj" />
+    <TestAssets Include="$(MSBuildThisFileDirectory)../assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/JUnit.Xml.TestLogger.XUnit.NetCore.Tests.csproj" />
   </ItemGroup>
   <Target Name="TestTarget" BeforeTargets="Build">
     <Message Importance="High" Text="... Building test assets" />

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
@@ -124,20 +124,6 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
         }
 
         [TestMethod]
-        public void TestResultFileShouldContainXUnitTraitAsProperty()
-        {
-            var properties = this.resultsXml.XPathSelectElement(
-                "/testsuites/testsuite//testcase[@classname=\"NUnit.Xml.TestLogger.Tests2.ApiTest\"]/properties");
-            Assert.IsNotNull(properties);
-            Assert.AreEqual(1, properties.Nodes().Count());
-
-            var firstProperty = properties.Nodes().First() as XElement;
-            Assert.IsNotNull(firstProperty);
-            Assert.AreEqual("SomeProp", firstProperty.Attribute("name").Value);
-            Assert.AreEqual("SomeVal", firstProperty.Attribute("value").Value);
-        }
-
-        [TestMethod]
         public void TestResultFileShouldContainNUnitCategoryAsProperty()
         {
             var tesuites = this.resultsXml.XPathSelectElement("/testsuites/testsuite");

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
@@ -37,9 +37,9 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             // Enable reporting of internal properties in the adapter using runsettings
             _ = DotnetTestFixture
-                    .Create()
-                    .WithBuild()
-                    .Execute(AssetName, loggerArgs, collectCoverage: false, "test-results.xml");
+                .Create()
+                .WithBuild()
+                .Execute(AssetName, loggerArgs, collectCoverage: false, "test-results.xml");
         }
 
         [TestMethod]
@@ -121,6 +121,45 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             Assert.IsTrue(node.Value.Contains("{D46DFA10-EEDD-49E5-804D-FE43051331A7}"));
             Assert.IsTrue(node.Value.Contains("{33F5FD22-6F40-499D-98E4-481D87FAEAA1}"));
+        }
+
+        [TestMethod]
+        public void TestResultFileShouldContainXUnitTraitAsProperty()
+        {
+            var properties = this.resultsXml.XPathSelectElement(
+                "/testsuites/testsuite//testcase[@classname=\"NUnit.Xml.TestLogger.Tests2.ApiTest\"]/properties");
+            Assert.IsNotNull(properties);
+            Assert.AreEqual(1, properties.Nodes().Count());
+
+            var firstProperty = properties.Nodes().First() as XElement;
+            Assert.IsNotNull(firstProperty);
+            Assert.AreEqual("SomeProp", firstProperty.Attribute("name").Value);
+            Assert.AreEqual("SomeVal", firstProperty.Attribute("value").Value);
+        }
+
+        [TestMethod]
+        public void TestResultFileShouldContainNUnitCategoryAsProperty()
+        {
+            var tesuites = this.resultsXml.XPathSelectElement("/testsuites/testsuite");
+            var testcase = tesuites
+                .Nodes()
+                .FirstOrDefault(n =>
+                {
+                    var element = n as XElement;
+                    return element.Attribute("classname")?.Value == "JUnit.Xml.TestLogger.NetFull.Tests.UnitTest1" &&
+                           element.Attribute("name")?.Value == "WithProperties";
+                });
+            Assert.IsNotNull(testcase);
+
+            var properties = (testcase as XElement)
+                .Nodes()
+                .FirstOrDefault(n => (n as XElement)?.Name == "properties") as XElement;
+            Assert.IsNotNull(properties);
+            Assert.AreEqual(2, properties.Nodes().Count());
+            var propertyElements = properties.Nodes().ToList();
+
+            Assert.AreEqual("Property name", (propertyElements[0] as XElement).Attribute("name").Value);
+            Assert.AreEqual("Property value 1", (propertyElements[0] as XElement).Attribute("value").Value);
         }
 
         [TestMethod]

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
@@ -98,7 +98,8 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
                 Assert.IsTrue(body.Trim().StartsWith(message.Trim()));
             }
 
-            Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));
+            var validator = new JunitXmlValidator();
+            Assert.IsTrue(validator.IsValid(resultsXml));
         }
 
         [TestMethod]

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerXUnitAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerXUnitAcceptanceTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Spekt Contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace JUnit.Xml.TestLogger.AcceptanceTests
+{
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
+    using global::TestLogger.Fixtures;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Acceptance tests evaluate the most recent output of the build.ps1 script, NOT the most
+    /// recent build performed by visual studio or dotnet.build
+    ///
+    /// These acceptance tests look at the specific structure and contents of the produced Xml,
+    /// when running using the xUnit vstest runner.
+    /// </summary>
+    [TestClass]
+    public class JUnitTestLoggerXunitAcceptanceTests
+    {
+        private const string AssetName = "JUnit.Xml.TestLogger.XUnit.NetCore.Tests";
+        private readonly string resultsFile;
+        private readonly XDocument resultsXml;
+
+        public JUnitTestLoggerXunitAcceptanceTests()
+        {
+            this.resultsFile = Path.Combine(AssetName.ToAssetDirectoryPath(), "test-results.xml");
+            this.resultsXml = XDocument.Load(this.resultsFile);
+        }
+
+        [ClassInitialize]
+        public static void SuiteInitialize(TestContext context)
+        {
+            var loggerArgs = "junit;LogFilePath=test-results.xml";
+
+            // Enable reporting of internal properties in the adapter using runsettings
+            _ = DotnetTestFixture
+                .Create()
+                .WithBuild()
+                .Execute(AssetName, loggerArgs, collectCoverage: false, "test-results.xml");
+        }
+
+        [TestMethod]
+        public void LoggedXmlValidatesAgainstXsdSchema()
+        {
+            var validator = new JunitXmlValidator();
+            var result = validator.IsValid(File.ReadAllText(this.resultsFile));
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void TestResultFileShouldContainXUnitTraitAsProperty()
+        {
+            var properties = this.resultsXml.XPathSelectElement(
+                "/testsuites/testsuite//testcase[@classname=\"NUnit.Xml.TestLogger.Tests2.ApiTest\"]/properties");
+            Assert.IsNotNull(properties);
+            Assert.AreEqual(2, properties.Nodes().Count());
+            foreach (XElement node in properties.Nodes())
+            {
+                Assert.IsNotNull(node);
+                if (node.Attribute("name").Value == "SomeProp")
+                {
+                    Assert.AreEqual("SomeVal", node.Attribute("value").Value);
+                }
+                else if (node.Attribute("name").Value == "Category")
+                {
+                    Assert.AreEqual("ApiTest", node.Attribute("value").Value);
+                }
+                else
+                {
+                    Assert.Fail($"Unexpted property found");
+                }
+            }
+        }
+    }
+}

--- a/test/TestLogger.UnitTests/Extensions/MSTestAdapterTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/MSTestAdapterTests.cs
@@ -55,5 +55,25 @@ namespace Spekt.TestLogger.UnitTests.Extensions
             Assert.AreEqual(1, transformedResults.Count);
             Assert.AreEqual(Method, transformedResults.Single().Method);
         }
+
+        [TestMethod]
+        public void TransformResultShouldAddProperties()
+        {
+            var testResults = new List<TestResultInfo>
+            {
+                new TestResultInfoBuilder("namespace", "type", Method)
+                    .WithProperty("Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestProperty", new[] { "c1", "c2" })
+                    .Build(),
+            };
+
+            var sut = new MSTestAdapter();
+
+            var transformedResults = sut.TransformResults(testResults, new List<TestMessageInfo>());
+
+            Assert.AreEqual(1, transformedResults.Count);
+            Assert.AreEqual(1, transformedResults[0].Properties.Count);
+            Assert.AreEqual(Method, transformedResults.Single().Method);
+            CollectionAssert.AreEquivalent(new[] { "c1", "c2" }, (string[])transformedResults[0].Properties.Single(p => p.Key == "CustomProperty").Value);
+        }
     }
 }

--- a/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/NUnitTestAdapterTests.cs
@@ -97,5 +97,23 @@ namespace Spekt.TestLogger.UnitTests.Extensions
             Assert.AreEqual(1, modifiedResults[0].Properties.Where(p => p.Key == "NUnit.Seed").Single().Value);
             CollectionAssert.AreEquivalent(new[] { "c1", "c2" }, (string[])modifiedResults[0].Properties.Where(p => p.Key == "NUnit.TestCategory").Single().Value);
         }
+
+        [TestMethod]
+        public void TransformResultShouldAddProperties()
+        {
+            var results = new List<TestResultInfo>
+            {
+                new TestResultInfoBuilder(DummyNamespace, DummyType, DummyMethod)
+                    .WithOutcome(TestOutcome.Passed)
+                    .WithProperty("NUnit.Category", new[] { "c1", "c2" })
+                    .Build()
+            };
+
+            var modifiedResults = this.adapter.TransformResults(results, new ());
+
+            Assert.AreEqual(1, modifiedResults.Count);
+            Assert.AreEqual(1, modifiedResults[0].Properties.Count);
+            CollectionAssert.AreEquivalent(new[] { "c1", "c2" }, (string[])modifiedResults[0].Properties.Single(p => p.Key == "CustomProperty").Value);
+        }
     }
 }

--- a/test/TestLogger.UnitTests/Extensions/XunitTestAdapterTests.cs
+++ b/test/TestLogger.UnitTests/Extensions/XunitTestAdapterTests.cs
@@ -57,5 +57,29 @@ namespace Spekt.TestLogger.UnitTests.Extensions
             Assert.AreEqual(1, transformedResults.Count(x => x.Method == "M1"));
             Assert.AreEqual(1, transformedResults.Count(x => x.Method == "M2(some args)"));
         }
+
+        [TestMethod]
+        public void TransformResultShouldAddProperties()
+        {
+            var results = new List<TestResultInfo>
+            {
+                new TestResultInfoBuilder("N", "C", "M1")
+                    .WithOutcome(TestOutcome.Passed)
+                    .WithTraits([new Trait("traitKey", "traitVal")])
+                    .WithProperty("Xunit.Trait", new string[] { "key", "val" })
+                    .Build()
+            };
+
+            var messages = new List<TestMessageInfo>();
+            var xunit = new XunitTestAdapter();
+
+            var transformedResults = xunit.TransformResults(results, messages);
+            Assert.AreEqual(1, transformedResults.Count);
+            Assert.AreEqual(1, transformedResults.Count(x => x.Method == "M1"));
+
+            var parsedProperty = transformedResults[0].Properties.First();
+            Assert.AreEqual("CustomProperty", parsedProperty.Key);
+            CollectionAssert.AreEquivalent(parsedProperty.Value as string[], new[] { "key", "val" });
+        }
     }
 }

--- a/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/JUnit.Xml.TestLogger.XUnit.NetCore.Tests.csproj
+++ b/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/JUnit.Xml.TestLogger.XUnit.NetCore.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!-- Disable stylecop for test assets -->
+    <StylecopEnabled>false</StylecopEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../src/JUnit.Xml.TestLogger/JUnit.Xml.TestLogger.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(NETTestSdkMinimumVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitTestAdapterVersion)" /> 
+  </ItemGroup>
+
+</Project>

--- a/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/UnitTest4.cs
+++ b/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/UnitTest4.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+using Xunit.Abstractions;
+
+namespace NUnit.Xml.TestLogger.Tests2
+{
+    public class ApiTest
+    {
+        [Fact]
+        [ApiTest]
+        [Trait("SomeProp", "SomeVal")]
+        public void ExampleTest()
+        {
+            Assert.False(false);
+        }
+    }
+}

--- a/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/XUnitTraitDiscoverer.cs
+++ b/test/assets/JUnit.Xml.TestLogger.XUnit.NetCore.Tests/XUnitTraitDiscoverer.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+using Xunit.Abstractions;
+
+namespace NUnit.Xml.TestLogger.Tests2
+{
+    [TraitDiscoverer("NUnit.Xml.TestLogger.Tests2.ApiTestTraitDiscoverer", "JUnit.Xml.TestLogger.XUnit.NetCore.Tests")]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public sealed class ApiTestAttribute : Attribute, ITraitAttribute
+    {
+    }
+
+    public class ApiTestTraitDiscoverer : ITraitDiscoverer
+    {
+        private const string CategoryKey = "Category";
+        private const string CategoryName = "ApiTest";
+
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            yield return new KeyValuePair<string, string>(CategoryKey, CategoryName);
+        }
+    }
+}

--- a/test/assets/JUnit.xsd
+++ b/test/assets/JUnit.xsd
@@ -27,9 +27,11 @@
  ********************************************************************************
 
 Modifications to original xsd for this repo:
-1. 2024/12: Allow `property` with minOccurs = 0.
+1. 2024/12 @codito: Allow `property` with minOccurs = 0.
+2. 2025/02 @timo-reymann: Allow elements in `properties` to have mixed order
+3. 2025/05 @timo-reymann: Add `properties` to test case element
 
- -->
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xs:element name="failure">
@@ -67,13 +69,14 @@ Modifications to original xsd for this repo:
 
     <xs:element name="testcase">
         <xs:complexType>
-            <xs:sequence>
+            <xs:all>
                 <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
-                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" />
+                <xs:element ref="failure" minOccurs="0" />
+                <xs:element ref="system-out" minOccurs="0"/>
+                <xs:element ref="system-err" minOccurs="0"/>
+            </xs:all>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="assertions" type="xs:string" use="optional"/>
             <xs:attribute name="time" type="xs:string" use="optional"/>


### PR DESCRIPTION
This adds support for adding custom properties to the junit testcase element, based on the framework.

This supports:
- `NUnit.Category`
- `XUnit.Trait` (either directly attached to a method or discovered via [`XUnit.TraitDiscoverer`](https://github.com/xunit/xunit/blob/master/src/xunit.core/Sdk/ITraitDiscoverer.cs))
- `Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestProperty`

## Changes

Brief overview of the changes to areas of the project

### GitHub actions
- Force color output for dotnet - that makes it easier to detect and read error messages in action logs
- Set up nuget cache using cache action (please note that with v4 this is natively integrated, I did not manage to set up v4 without too much fiddling with existing config)

> If you are open for upgrading to v4 of the dotnet action I can also give it a spin, in a dedicated PR, please just let me know

### Logger

- Extends junit xml serializer

### Testing
- Created a new test (assets) project `JUnit.Xml.TestLogger.XUnit.NetCore.Tests` to verify the xUnit discoverer, also combined with traits works
- Create new test suite `JUnitTestLoggerXUnitAcceptanceTests` to run the added xUnit project
- Extended Junit.xsd schema & changes the inline format for changes to the file to make it easier to track down

> Not entirely sure if thats the appropiate way to do for this repository, this way logic can be tested easily with xUnit