### PR TITLE
fix: emit file and line attributes on JUnit testcase

### DIFF
--- a/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
+++ b/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
@@ -359,6 +359,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
             // seconds should be low enough it won't interfere with anyone monitoring test duration.
             testcaseElement.SetAttributeValue("time", Math.Max(0.0000001f, result.Duration.TotalSeconds).ToString("0.0000000", CultureInfo.InvariantCulture));
 
+            if (!string.IsNullOrEmpty(result.CodeFilePath))
+            {
+                testcaseElement.SetAttributeValue("file", result.CodeFilePath);
+            }
+
+            if (result.LineNumber > 0)
+            {
+                testcaseElement.SetAttributeValue("line", result.LineNumber);
+            }
+
             if (result.Outcome == TestOutcome.Failed)
             {
                 var failureBodySB = new StringBuilder();

--- a/test/JUnit.Xml.TestLogger.UnitTests/JUnitXmlTestSerializerTests.cs
+++ b/test/JUnit.Xml.TestLogger.UnitTests/JUnitXmlTestSerializerTests.cs
@@ -224,6 +224,40 @@ namespace JUnit.Xml.TestLogger.UnitTests
             Assert.IsTrue(systemErrElement.Value.Contains("Error - Error message"));
         }
 
+        [TestMethod]
+        public void TestCaseShouldIncludeFileAndLineAttributesWhenSourceIsPresent()
+        {
+            var serializer = new JunitXmlSerializer();
+            var result = CreateTestResultInfo();
+
+            var testCase = SerializeAndGetTestCaseElement(serializer, result);
+
+            Assert.AreEqual(TestCsPath, testCase.Attribute("file")?.Value);
+            Assert.AreEqual("42", testCase.Attribute("line")?.Value);
+        }
+
+        [TestMethod]
+        public void TestCaseShouldOmitFileAttributeWhenCodeFilePathIsMissing()
+        {
+            var serializer = new JunitXmlSerializer();
+            var result = CreateTestResultInfo(codeFilePath: null);
+
+            var testCase = SerializeAndGetTestCaseElement(serializer, result);
+
+            Assert.IsNull(testCase.Attribute("file"));
+        }
+
+        [TestMethod]
+        public void TestCaseShouldOmitLineAttributeWhenLineNumberIsMissing()
+        {
+            var serializer = new JunitXmlSerializer();
+            var result = CreateTestResultInfo(lineNumber: 0);
+
+            var testCase = SerializeAndGetTestCaseElement(serializer, result);
+
+            Assert.IsNull(testCase.Attribute("line"));
+        }
+
         private static LoggerConfiguration CreateTestLoggerConfiguration()
         {
             return new LoggerConfiguration(new Dictionary<string, string>
@@ -237,7 +271,11 @@ namespace JUnit.Xml.TestLogger.UnitTests
             return new TestRunConfiguration { StartTime = DateTime.Now };
         }
 
-        private static TestResultInfo CreateTestResultInfo(TestOutcome outcome = TestOutcome.Passed, List<TestResultMessage> messages = null)
+        private static TestResultInfo CreateTestResultInfo(
+            TestOutcome outcome = TestOutcome.Passed,
+            List<TestResultMessage> messages = null,
+            string codeFilePath = TestCsPath,
+            int lineNumber = 42)
         {
             return new TestResultInfo(
                 TestNamespace,
@@ -248,8 +286,8 @@ namespace JUnit.Xml.TestLogger.UnitTests
                 TestDisplayName,
                 TestDisplayName,
                 TestDllPath,
-                TestCsPath,
-                42,
+                codeFilePath,
+                lineNumber,
                 DateTime.Now,
                 DateTime.Now.AddSeconds(1),
                 TimeSpan.FromSeconds(1),
@@ -262,7 +300,7 @@ namespace JUnit.Xml.TestLogger.UnitTests
                 null);
         }
 
-        private static string SerializeAndExtractElementContent(JunitXmlSerializer serializer, TestResultInfo result, string elementName)
+        private static XElement SerializeAndGetTestCaseElement(JunitXmlSerializer serializer, TestResultInfo result)
         {
             var xml = serializer.Serialize(
                 CreateTestLoggerConfiguration(),
@@ -272,6 +310,13 @@ namespace JUnit.Xml.TestLogger.UnitTests
 
             var doc = XDocument.Parse(xml);
             var testCaseElement = doc.XPathSelectElement("//testcase");
+            Assert.IsNotNull(testCaseElement, "testcase element not found");
+            return testCaseElement;
+        }
+
+        private static string SerializeAndExtractElementContent(JunitXmlSerializer serializer, TestResultInfo result, string elementName)
+        {
+            var testCaseElement = SerializeAndGetTestCaseElement(serializer, result);
             var targetElement = testCaseElement.Element(elementName);
 
             Assert.IsNotNull(targetElement, $"Element '{elementName}' not found in testcase");

--- a/test/assets/JUnit.xsd
+++ b/test/assets/JUnit.xsd
@@ -82,6 +82,8 @@ Modifications to original xsd for this repo:
             <xs:attribute name="time" type="xs:string" use="optional"/>
             <xs:attribute name="classname" type="xs:string" use="optional"/>
             <xs:attribute name="status" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="line" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
## Context

The JUnit logger's `<testcase>` elements omit `file` and `line`. VSTest passes `TestCase.CodeFilePath` / `LineNumber` to the logger and `TestResultInfo` carries them, but the serializer doesn't emit them. The result is a blank Filename column in GitLab's Unit test reports UI — where "blank" renders as the literal string `null`.

This change adds a block in `CreateTestCaseElement` that reads those properties and emits them as attributes when present. The Jenkins JUnit XSD permits both, so the change is additive.

**User-side requirement:** populating the attributes requires `<CollectSourceInformation>true</CollectSourceInformation>` in the consumer's runsettings — the VSTest gate that tells xUnit/MSTest adapters to read PDBs. Without it, `CodeFilePath` arrives empty and the attributes are omitted (same as today).

## Review guide

**Core change**
- [`src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs:362`](https://github.com/spekt/testlogger/pull/236/files#diff-56217e894db0e3725c413a57421c501a1c68f6aa4f8b8e801f58bbebf7cb9b88R362) — emit `file` when `CodeFilePath` is non-empty, `line` when `LineNumber > 0`

**Schema**
- [`test/assets/JUnit.xsd:85`](https://github.com/spekt/testlogger/pull/236/files#diff-673cd2d02ae5635ec96cc7be35bd6a89f07b863f2c5d1e5365fd597f6216ff98R85) — add the two optional attributes so the acceptance-test XSD validator accepts the new output

**Tests**
- [`test/JUnit.Xml.TestLogger.UnitTests/JUnitXmlTestSerializerTests.cs:227`](https://github.com/spekt/testlogger/pull/236/files#diff-88b3493fe2255841e0fef7d651b4d184b8f4d111d04c1c7d91c8baf98eef21efR227) — three cases: attributes present when source info is supplied, `file` omitted when path is missing, `line` omitted when `0`

Sibling formats unchanged: `Xunit.Xml.TestLogger` already emits `<source-file>`/`<source-line>` children on `<test>` (different format); `NUnit.Xml.TestLogger`'s schema has no equivalent attributes.

Resolves #235
